### PR TITLE
To not include Tenant Name/Id in Authentication

### DIFF
--- a/docs/api/openstack.inc.html
+++ b/docs/api/openstack.inc.html
@@ -1445,7 +1445,7 @@ password, but Rackspace uses a username, tenant ID, and API key.
 <td>$secret</td>
 <td style="white-space: normal;">array</td>
 <td><ul>
-<li>an associative array of auth information: * username * password * tenantName</li>
+<li>an associative array of auth information: * username * password</li>
 </ul>
 </td>
 <td></td>

--- a/docs/api/rackspace.inc.html
+++ b/docs/api/rackspace.inc.html
@@ -86,8 +86,8 @@ than the pure OpenStack class)<br><br><a name="includes"></a><h2>Includes</h2>op
 <h4>Description</h4>
 <em>Rackspace extends the OpenStack class with support for Rackspace's
 API key and tenant requirements.</em><br><p>The only difference between Rackspace and OpenStack is that the
-Rackspace class generates credentials using the username,
-tenantName (ID), and API key, as required by the Rackspace authentication
+Rackspace class generates credentials using the username
+and API key, as required by the Rackspace authentication
 service.</p>
 
 <p>Example:</p>
@@ -99,7 +99,6 @@ $conn = new Rackspace(
      'http://identity.rackspace.com/v2/',
      array(
          'username' => $username,
-         'tenantName' => $tenant,
          'apiKey' => $apiKey
      ));
 </code></pre><br><div id="methods_Rackspace">
@@ -1733,7 +1732,7 @@ password, but Rackspace uses a username, tenant ID, and API key.
 <td>$secret</td>
 <td style="white-space: normal;">array</td>
 <td><ul>
-<li>an associative array of auth information: * username * password * tenantName</li>
+<li>an associative array of auth information: * username * password</li>
 </ul>
 </td>
 <td></td>

--- a/docs/api/structure.xml
+++ b/docs/api/structure.xml
@@ -6999,7 +6999,7 @@ password, but Rackspace uses a username, tenant ID, and API key.
           <tag line="141" name="param" description="- the authentication endpoint URL" type="string" variable="$url">
             <type by_reference="false">string</type>
           </tag>
-          <tag line="141" name="param" description="- an associative array of auth information: * username * password * tenantName" type="array" variable="$secret">
+          <tag line="141" name="param" description="- an associative array of auth information: * username * password" type="array" variable="$secret">
             <type by_reference="false">array</type>
           </tag>
         </docblock>
@@ -8171,20 +8171,17 @@ than the pure OpenStack class)]]></description>
         <description><![CDATA[Rackspace extends the OpenStack class with support for Rackspace's
 API key and tenant requirements.]]></description>
         <long-description><![CDATA[<p>The only difference between Rackspace and OpenStack is that the
-Rackspace class generates credentials using the username,
-tenantName (ID), and API key, as required by the Rackspace authentication
-service.</p>
+Rackspace class generates credentials using the username and API key, 
+as required by the Rackspace authentication service.</p>
 
 <p>Example:</p>
 
 <pre><code>$username = 'FRED';
-$tenant = '1234560';
 $apiKey = '0900af093093788912388fc09dde090ffee09';
 $conn = new Rackspace(
-     'http://identity.rackspace.com/v2/',
+     'https://identity.api.rackspacecloud.com/v2.0/',
      array(
          'username' => $username,
-         'tenantName' => $tenant,
          'apiKey' => $apiKey
      ));
 </code></pre>]]></long-description>

--- a/docs/quickref.md
+++ b/docs/quickref.md
@@ -39,8 +39,7 @@ username and password:
 		'https://example.com/v2/identity',
 		array(
 			'username' => 'your username',
-			'password' => 'your Keystone password',
-			'tenantName' => 'your tenant name'
+			'password' => 'your Keystone password'
 		));
 
 (Note that the `tenantName` value may not be required for all installations.)
@@ -53,8 +52,7 @@ API key and tenant ID instead:
 		'https://example.com/v2/identity',
 		array(
 			'username' => 'your username',
-			'apiKey' => 'your API key',
-			'tenantName' => 'your tenant ID'
+			'apiKey' => 'your API key'
 		));
 
 The connection object can be re-used at will (so long as you're

--- a/docs/userguide/authentication.md
+++ b/docs/userguide/authentication.md
@@ -34,8 +34,7 @@ Next, create an `OpenStack` object with the proper credentials:
     $endpoint = 'https://your-cloud-provider/path';
     $credentials = array(
         'username' => 'YOUR USERNAME',
-        'password' => 'YOUR PASSWORD',
-        'tenantName' => 'YOUR TENANT NAME'
+        'password' => 'YOUR PASSWORD'
     );
     $cloud = new OpenCloud\OpenStack($endpoint, $credentials);
 
@@ -57,15 +56,13 @@ Next, create a `Rackspace` object with the proper credentials:
     $endpoint = 'https://identity.api.rackspacecloud.com/v2.0/';
     $credentials = array(
         'username' => 'YOUR USERNAME',
-        'tenantName' => 'YOUR TENANT NAME',
         'apiKey' => 'YOUR API KEY'
     );
     $cloud = new OpenCloud\Rackspace($endpoint, $credentials);
 
-Replace the values for `username`, `tenantName` (sometimes called the *tenant ID* or
-the *customer ID* in Rackspace documentation), and `apiKey` with the values for your
-account. If you don't have an API key, see
-[@TODO need link for API key].
+Replace the values for `username` and `apiKey` with the values for your
+account. If you don't have an API key, see:
+https://mycloud.rackspace.com/a/`username`/account/api-keys
 
 Note that Rackspace UK users will have a different `$endpoint` than US users.
 

--- a/docs/userguide/services.md
+++ b/docs/userguide/services.md
@@ -92,7 +92,6 @@ It looks like this:
     [Identity]
     url = "https://identity.api.rackspacecloud.com/v2.0/"
     username = "{username}"
-    tenantName = "{tenant}"
     apiKey = "{apikey}"
     [Compute]
     serviceName = "cloudServersOpenStack"

--- a/lib/openstack.inc
+++ b/lib/openstack.inc
@@ -119,8 +119,7 @@ class OpenStack extends \OpenCloud\Base {
     "passwordCredentials": {
       "username":"%s",
       "password":"%s"
-    },
-    "tenantName":"%s"
+    }
   }
 }
 ENDAUTHTEMPLATE
@@ -153,7 +152,6 @@ ENDAUTHTEMPLATE
      * @param array $secret - an associative array of auth information:
      * * username
      * * password
-     * * tenantName
      */
 	public function __construct($url, $secret) {
 		$this->debug(_('initializing'));
@@ -233,12 +231,12 @@ ENDAUTHTEMPLATE
      * @return string
      */
 	public function Credentials() {
-		if (isset($this->secret['username'])&&isset($this->secret['password']))
+		if (isset($this->secret['username']) &&
+            isset($this->secret['password']))
 			return sprintf(
 				$this->template,
 				$this->secret['username'],
-				$this->secret['password'],
-				$this->secret['tenantName']);
+				$this->secret['password']);
 		else
 			throw new CredentialError(
 				_('Unrecognized credential secret'));
@@ -262,7 +260,7 @@ ENDAUTHTEMPLATE
 		$json = $response->HttpBody();
 
 		// check for errors
-		if ($response->HttpStatus() >= 300) {
+		if ($response->HttpStatus() >= 400) {
 			throw new AuthenticationError(
 				sprintf(_('Authentication failure, status [%d], response [%s]'),
 					$response->HttpStatus(), $json));

--- a/lib/rackspace.inc
+++ b/lib/rackspace.inc
@@ -22,20 +22,18 @@ require_once('lbservice.inc');
  * API key and tenant requirements.
  *
  * The only difference between Rackspace and OpenStack is that the
- * Rackspace class generates credentials using the username,
- * tenantName (ID), and API key, as required by the Rackspace authentication
+ * Rackspace class generates credentials using the username
+ * and API key, as required by the Rackspace authentication
  * service.
  *
  * Example:
  * <code>
  * $username = 'FRED';
- * $tenant = '1234560';
  * $apiKey = '0900af093093788912388fc09dde090ffee09';
  * $conn = new Rackspace(
- *      'http://identity.rackspace.com/v2/',
+ *      'https://identity.api.rackspacecloud.com/v2.0/',
  *      array(
  *          'username' => $username,
- *          'tenantName' => $tenant,
  *          'apiKey' => $apiKey
  *      ));
  * </code>
@@ -44,7 +42,6 @@ class Rackspace extends OpenStack {
 //this is the JSON string for our new credentials
 const APIKEYTEMPLATE = <<<ENDCRED
 { "auth": { "RAX-KSKEY:apiKeyCredentials": { "username": "%s",
-          "tenantName": "%s",
           "apiKey": "%s"
         }
     }
@@ -59,12 +56,10 @@ ENDCRED;
     public function Credentials() {
     	$sec = $this->Secret();
     	if (isset($sec['username']) &&
-    		isset($sec['tenantName']) &&
     		isset($sec['apiKey']))
 			return sprintf(
 				self::APIKEYTEMPLATE,
 				$sec['username'],
-				$sec['tenantName'],
 				$sec['apiKey']
 		   );
 		else

--- a/samples/auth.ini
+++ b/samples/auth.ini
@@ -3,7 +3,6 @@
 [Identity]
 url = "https://identity.api.rackspacecloud.com/v2.0/"
 username = "{username}"
-tenantName = "{tenant}"
 apiKey = "{apikey}"
 
 [Compute]

--- a/samples/auth_rax.php
+++ b/samples/auth_rax.php
@@ -11,7 +11,6 @@ require_once('compute.inc');
 define('AUTHURL', 'https://identity.api.rackspacecloud.com/v2.0/');
 $mysecret = array(
     'username' => '{username}',
-    'tenantName' => '{tenantName}',
     'apiKey' => '{apiKey}'
 );
 

--- a/samples/cleanup.php
+++ b/samples/cleanup.php
@@ -52,7 +52,6 @@ printf("Endpoint [%s]\n", $_ENV['NOVA_URL']);
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to Cloud Servers');

--- a/samples/compute/attachments.php
+++ b/samples/compute/attachments.php
@@ -36,7 +36,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the Compute Service');

--- a/samples/compute/create.php
+++ b/samples/compute/create.php
@@ -15,7 +15,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/cross-region.php
+++ b/samples/compute/cross-region.php
@@ -25,7 +25,6 @@ printf("Authenticating...\n");
 // establish our credentials
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service in Dallas and Chicago

--- a/samples/compute/delete.php
+++ b/samples/compute/delete.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/extensions.php
+++ b/samples/compute/extensions.php
@@ -32,7 +32,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the Compute Service');

--- a/samples/compute/flavors.php
+++ b/samples/compute/flavors.php
@@ -15,7 +15,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/images.php
+++ b/samples/compute/images.php
@@ -15,7 +15,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/metadata.php
+++ b/samples/compute/metadata.php
@@ -15,7 +15,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/networks.php
+++ b/samples/compute/networks.php
@@ -38,7 +38,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to Cloud Servers');

--- a/samples/compute/overlimit.php
+++ b/samples/compute/overlimit.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/reboot.php
+++ b/samples/compute/reboot.php
@@ -10,7 +10,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 $cservers = $rackspace->Compute('cloudServersOpenStack', 'DFW');
 $list = $cservers->ServerList();

--- a/samples/compute/rescue.php
+++ b/samples/compute/rescue.php
@@ -27,7 +27,6 @@ function dot($server) {
 }
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 $cservers = $rackspace->Compute('cloudServersOpenStack', 'DFW');
 $list = $cservers->ServerList();

--- a/samples/compute/resize.php
+++ b/samples/compute/resize.php
@@ -11,7 +11,6 @@ define('MYREGION', $_ENV['OS_REGION_NAME']);
 
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 $cservers = $rackspace->Compute('cloudServersOpenStack', MYREGION);
 $list = $cservers->ServerList();

--- a/samples/compute/serverlist.php
+++ b/samples/compute/serverlist.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/compute/simple.php
+++ b/samples/compute/simple.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 printf("Establish our credentials...\n");
 $connection = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 printf("Connect to the compute service...\n");

--- a/samples/compute/simplecreate.php
+++ b/samples/compute/simplecreate.php
@@ -11,7 +11,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 print "Authenticating...\n";
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 $compute = $rackspace->Compute('cloudServersOpenStack', 'DFW');
 $server = $compute->Server();

--- a/samples/compute/snapshot.php
+++ b/samples/compute/snapshot.php
@@ -39,7 +39,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the VolumeService');

--- a/samples/compute/volumes.php
+++ b/samples/compute/volumes.php
@@ -38,7 +38,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the Compute Service');

--- a/samples/database/create.php
+++ b/samples/database/create.php
@@ -13,7 +13,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/database/delete.php
+++ b/samples/database/delete.php
@@ -13,7 +13,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/database/flavors.php
+++ b/samples/database/flavors.php
@@ -13,7 +13,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/database/list.php
+++ b/samples/database/list.php
@@ -13,7 +13,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the compute service

--- a/samples/loadbalancers/createlb.php
+++ b/samples/loadbalancers/createlb.php
@@ -36,7 +36,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the Load Balancer Service');

--- a/samples/loadbalancers/listlb.php
+++ b/samples/loadbalancers/listlb.php
@@ -35,7 +35,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Connect to the Load Balancer Service');

--- a/samples/objectstore/cdn.php
+++ b/samples/objectstore/cdn.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the ObjectStore service

--- a/samples/objectstore/container.php
+++ b/samples/objectstore/container.php
@@ -16,7 +16,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 // now, connect to the ObjectStore service

--- a/samples/objectstore/createobj.php
+++ b/samples/objectstore/createobj.php
@@ -23,7 +23,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array('username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY));
 
 // create a Cloud Files (ObjectStore) connection

--- a/samples/objectstore/filter.php
+++ b/samples/objectstore/filter.php
@@ -25,7 +25,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array('username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY));
 
 // create a Cloud Files (ObjectStore) connection

--- a/samples/objectstore/objstore.php
+++ b/samples/objectstore/objstore.php
@@ -19,7 +19,6 @@ define('APIKEY', $_ENV['NOVA_API_KEY']);
 // establish our credentials
 $connection = new Rackspace(AUTHURL,
 	array('username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY));
 
 // create a Cloud Files (ObjectStore) connection

--- a/samples/services.php
+++ b/samples/services.php
@@ -36,7 +36,6 @@ define('TIMEFORMAT', 'r');
 step('Authenticate');
 $rackspace = new OpenCloud\Rackspace(AUTHURL,
 	array( 'username' => USERNAME,
-		   'tenantName' => TENANT,
 		   'apiKey' => APIKEY ));
 
 step('Listing Services');

--- a/tests/RackspaceTest.php
+++ b/tests/RackspaceTest.php
@@ -35,13 +35,13 @@ class RackspaceTest extends PHPUnit_Framework_TestCase
 	public function testCredentials() {
 		$this->conn = new MyRackspace(
 			'http://example.com',
-			array('username'=>'FOO', 'password'=>'BAR', 'tenantName'=>'BAZ'));
+			array('username'=>'FOO', 'password'=>'BAR'));
 		$this->assertRegExp(
 			'/"username":"FOO"/',
 			$this->conn->Credentials());
 		$this->conn = new MyRackspace(
 			'http://example.com',
-			array('username'=>'FOO','tenantName'=>'TENANT','apiKey'=>'KEY'));
+			array('username'=>'FOO','apiKey'=>'KEY'));
 		$this->assertRegExp(
 			'/RAX-KSKEY:apiKeyCredentials/', 
 			$this->conn->Credentials());


### PR DESCRIPTION
This allows an un-filtered (by Tenant) Service-Catalog.
