### PR TITLE
Allow submission of tenantName with initial auth

### DIFF
--- a/lib/openstack.inc
+++ b/lib/openstack.inc
@@ -113,17 +113,6 @@ class OpenStack extends \OpenCloud\Base {
 		$overlimit_timeout=RAXSDK_OVERLIMIT_TIMEOUT;
 
 	private
-		$template = <<<ENDAUTHTEMPLATE
-{
-  "auth": {
-    "passwordCredentials": {
-      "username":"%s",
-      "password":"%s"
-    }
-  }
-}
-ENDAUTHTEMPLATE
-,
 		$_user_write_progress_callback_func,
 		$_user_read_progress_callback_func,
 		/**
@@ -261,11 +250,25 @@ ENDAUTHTEMPLATE
      */
 	public function Credentials() {
 		if (isset($this->secret['username']) &&
-            isset($this->secret['password']))
-			return sprintf(
-				$this->template,
-				$this->secret['username'],
-				$this->secret['password']);
+			isset($this->secret['password']))
+		{
+			$credentials =
+				array( 'auth' =>
+					array( 'passwordCredentials' =>
+						array(
+							'username' => $this->secret['username'],
+							'password'=>$this->secret['password']
+						)
+					)
+				);
+
+			if (isset($this->secret['tenantName']))
+			{
+				$credentials['auth']['tenantName'] = $this->secret['tenantName'];
+			}
+
+			return json_encode($credentials);
+		}
 		else
 			throw new CredentialError(
 				_('Unrecognized credential secret'));


### PR DESCRIPTION
For non-rackspace installs, you need to supply tenantName with the initial authentication request in order to get a valid service catalog back.  This patch removes OpenStack::$template (switched to json_encode instead), and adds the ability to supply a tenantName during the initial auth process.

You would use this by doing the following:

```
$connection = new OpenStack(AUTHURL,
   array( 'username' => 'admin',
       'password' => 'PASSWORD',
       'tenantName' => 'admin' ));
```

This is somewhat related to #37, as the patch there won't really fix the problem fully (the auth request completes without warnings after that one, but nothing else will work as the service catalog is still empty)
