### PR TITLE
Change README links to full URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ so that you can still use the SDK with a pure OpenStack instance
 (for example, see the `OpenStack` class (for OpenStack) and the
 `Rackspace` subclass).
 
-See the [Release Notes](php-opencloud/blob/master/RELEASENOTES.md)
+See the [Release Notes](https://github.com/rackspace/php-opencloud/blob/master/RELEASENOTES.md)
 for what has changed in the latest release(s).
 
 See the [php-opencloud wiki](https://github.com/rackspace/php-opencloud/wiki)
@@ -91,26 +91,26 @@ then add the `lib/` directory to it:
 Further Reading
 ---------------
 The file
-[docs/quickref.md](php-opencloud/blob/master/docs/quickref.md)
+[docs/quickref.md](https://github.com/rackspace/php-opencloud/blob/master/docs/quickref.md)
 contains a Quick Reference
 guide to the
 **php-opencloud** library.
 
 The source for the "Getting Started with **php-opencloud**" document (the
 user's guide) starts in
-[docs/userguide/index.md](php-opencloud/blob/master/docs/userguide/index.md).
+[docs/userguide/index.md](https://github.com/rackspace/php-opencloud/blob/master/docs/userguide/index.md).
 
 There is a complete (auto-generated) API reference manual in the
 docs/api directory. Start with docs/api/index.html.
 
-See the [HOWTO.md](php-opencloud/blob/master/HOWTO.md) file for instructions on
+See the [HOWTO.md](https://github.com/rackspace/php-opencloud/blob/master/HOWTO.md) file for instructions on
 regenerating the documentation and running tests.
 
-See the [smoketest.php](php-opencloud/blob/master/smoketest.php) file for some
+See the [smoketest.php](https://github.com/rackspace/php-opencloud/blob/master/smoketest.php) file for some
 simple, working examples. This is a test we run before builds to ensure that all
 the core functionality is still working after code changes.
 
-The [samples/](php-opencloud/tree/master/samples/) directory has a collection
+The [samples/](https://github.com/rackspace/php-opencloud/tree/master/samples/) directory has a collection
 of tested, working sample code. Note that these may create objects in your cloud
 for which you could be charged.
 


### PR DESCRIPTION
These links were broken when viewing the repo on github.
