### PR TITLE
curl error code code 18

### DIFF
--- a/lib/http.php
+++ b/lib/http.php
@@ -83,6 +83,11 @@ class CurlRequest implements HTTPRequest {
             $this->setOption(CURLOPT_CAINFO, RAXSDK_CACERTPEM);
         }
 
+        //  curl code [18]
+        //	message [transfer closed with x bytes remaining to read]
+        if ($method === 'HEAD')
+        	$this->SetOption(CURLOPT_NOBODY, TRUE);
+
         // follow redirects
         $this->SetOption(CURLOPT_FOLLOWLOCATION, TRUE);
 


### PR DESCRIPTION
curl erro code: 18, message: transfer closed with X bytes remaining to read

where X is a number

is present when You retrieve object metadata

HEAD /<api version>/<account>/<container>/<object> HTTP/1.1
