### PR TITLE
ObjectStore Content-type and extra headers

### DIFF
--- a/lib/dataobject.php
+++ b/lib/dataobject.php
@@ -32,7 +32,8 @@ class DataObject extends ObjStoreBase {
         $bytes,             // size of object in bytes
         $last_modified,     // date of last modification
         $content_type,		// Content-Type:
-        $content_length;	// Content-Length:
+        $content_length,	// Content-Length:
+        $extra_headers;		// Other headers, eg. Access-Control-Allow-Origin:
 
     private
         $data,				// the actual data
@@ -149,6 +150,13 @@ class DataObject extends ObjStoreBase {
 		    $headers['ETag'] = $this->etag;
 		$headers['Content-Type'] = $this->content_type;
 		$headers['Content-Length'] = $this->content_length;
+
+		// copy any extra headers
+		if (!empty($this->extra_headers) ) {
+			foreach ($this->extra_headers as $header=>$value) {
+				$headers[$header] = $value;
+			}
+		}
 
 		// perform the request
 		$response = $this->Service()->Request(
@@ -481,6 +489,9 @@ class DataObject extends ObjStoreBase {
 			case 'content_type':
 				$this->content_type = $value;
 				break;
+			case 'extra_headers':
+				$this->extra_headers = $value;
+				break;
 			default:
 				throw new UnknownParameterError(
 				    sprintf(
@@ -512,6 +523,9 @@ class DataObject extends ObjStoreBase {
             return FALSE;
         }
 
+        if(!isset($this->extra_headers))
+            $this->extra_headers = array();
+
         // set headers as metadata?
         foreach($response->Headers() as $header => $value) {
             switch($header) {
@@ -522,6 +536,7 @@ class DataObject extends ObjStoreBase {
                 $this->content_length = $value;
                 break;
             default:
+                $this->extra_headers[$header] = $value;
                 break;
             }
         }


### PR DESCRIPTION
We need to upload objects with defined content-types, rather than relying on `_guess_content_type()`. The first commit checks to see if the content-type has already been set before guessing it.

In addition, we'd like to add extra headers such as `Access-Control-Allow-Origin:`. The second commit allows the inclusion of an extra parameter to the Create() `$params` array, called `extra_headers`, where arbitrary headers can be added to the `PUT` call.
