### PR TITLE
Add unit tests for #57

### DIFF
--- a/tests/DataObjectTest.php
+++ b/tests/DataObjectTest.php
@@ -82,6 +82,23 @@ class DataObjectTest extends PHPUnit_Framework_TestCase
 		// "type" is deprecated; this causes the exception
 		$obj->Create(array('name'=>'X','type'=>'error'));
 	}
+	public function testCreateContentType() {
+		$arr = array('name'=>'MOOFUS', 'content_type'=>'application/x-arbitrary-mime-type');
+		$obj = new OpenCloud\ObjectStore\DataObject($this->container);
+		$obj->Create($arr, __FILE__);
+		$this->assertEquals('application/x-arbitrary-mime-type', $obj->content_type);
+	}
+	public function testCreateWithHeaders() {
+		$arr = array('name'=>'HOOFUS',
+		             'extra_headers'=>array('Access-Control-Allow-Origin'=>'http://example.com'));
+		$obj = new OpenCloud\ObjectStore\DataObject($this->container);
+		$obj->Create($arr, __FILE__);
+		$this->assertEquals('http://example.com', $obj->extra_headers['Access-Control-Allow-Origin']);
+
+		//$obj2 = new OpenCloud\ObjectStore\DataObject($this->container, 'HOOFUS');
+		//$this->assertArrayHasKey('Access-Control-Allow-Origin', $obj2->extra_headers);
+		//$this->assertEquals('http://example.com', $obj2->extra_headers['Access-Control-Allow-Origin']);
+	}
 	public function testUpdate() {
 		$arr = array('name'=>'XOOFUS', 'content_type'=>'text/plain');
 		$obj = new OpenCloud\ObjectStore\DataObject($this->container);


### PR DESCRIPTION
As requested, some unit tests. I'm not sure how to test the retrieval of `extra_headers` while using a `StubConnection`, so I've commented those tests out.

The `Fetch` side of `extra_headers` does work in my own code, although it is a little... well, excessive. You might want to trim it a bit. Here's an example of `$obj->extra_headers`:

```
array (
  'HTTP/1.1 200 OK
' => 'HTTP/1.1 200 OK',
  'Accept-Ranges' => 'bytes',
  'Last-Modified' => 'Wed, 06 Mar 2013 23:53:49 GMT',
  'Etag' => 'e08565d09c128c9e093c8db3ac069040',
  'X-Timestamp' => '1362614029.88735',
  'Access-Control-Allow-Origin' => '*',
  'X-Trans-Id' => 'txab253b66c5e142caa619bfcdcf1a1d38',
  'Date' => 'Wed, 06 Mar 2013 23:53:49 GMT',
  '
' => '',
)
```

Ideally, most of those would be stripped out, leaving just the `Access-Control-Allow-Origin` header: the only header actually added by the first test!

Tom
