### PR TITLE
Prevent notice when trying to access non-existent header using Http::Header

### DIFF
--- a/lib/OpenCloud/Base/Request/Response/Http.php
+++ b/lib/OpenCloud/Base/Request/Response/Http.php
@@ -70,7 +70,7 @@ class Http extends \OpenCloud\Base\Base {
 	 * @return string with the value of the requested header, or NULL
 	 */
 	public function Header($name) {
-		return $this->headers[$name];
+		return isset($this->headers[$name]) ? $this->headers[$name] : NULL;
 	}
 
 	/**


### PR DESCRIPTION
Check to see if a header exists before attempting to access and return it to prevent from firing a PHP Notice.

If the header does not exist, return NULL.
