### PR TITLE
Fixes #102 - ETag header not used for OpenCloud\ObjectStore\DataObject::Create method.

### DIFF
--- a/lib/OpenCloud/ObjectStore/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/DataObject.php
@@ -27,13 +27,14 @@ use OpenCloud\AbstractClass\ObjectStore;
 class DataObject extends ObjectStore 
 {
 
-    public $name;            // the object name
-    public $hash;            // hash value of object
-    public $bytes;           // size of object in bytes
-    public $last_modified;   // date of last modification
-    public $content_type;    // Content-Type:
-    public $content_length;  // Content-Length:
-    public $extra_headers;   // Other headers, eg. Access-Control-Allow-Origin:
+    public $name;               // the object name
+    public $hash;               // hash value of object
+    public $bytes;              // size of object in bytes
+    public $last_modified;      // date of last modification
+    public $content_type;       // Content-Type:
+    public $content_length;     // Content-Length:
+    public $extra_headers;      // Other headers, eg. Access-Control-Allow-Origin:
+    public $send_etag = TRUE;   // Whether or not to calculate and send an etag on Create.
 
     private $data;           // the actual data
     private $etag;           // the ETag
@@ -144,10 +145,19 @@ class DataObject extends ObjectStore
                 $this->_guess_content_type($filename);
             }
 
+            if ($this->send_etag) {
+                $this->etag = md5_file($filename);
+            }
+
             $this->debug('Uploading %u bytes from %s', $filesize, $filename);
         } else {
             // compute the length
             $this->content_length = strlen($this->data);
+
+            if ($this->send_etag) {
+                $this->etag = md5($this->data);
+            }
+
         }
 
         // flag missing Content-Type
@@ -561,6 +571,9 @@ class DataObject extends ObjectStore
                     break;
                 case 'extra_headers':
                     $this->extra_headers = $value;
+                    break;
+                case 'send_etag':
+                    $this->send_etag = $value;
                     break;
                 default:
                     throw new Exceptions\UnknownParameterError(sprintf(


### PR DESCRIPTION
I fixed issue (#102)[https://github.com/rackspace/php-opencloud/issues/102] by
updating the OpenCloud\ObjectStore\DataObject::Create() method to automatically
set an md5 etag value if the new OpenCloud\ObjectStore\DataObject::$send_etag
property is set to a truish value. The new send_etag property is set to TRUE by
default. It is possible to either set the send_etag property to false by
modifying the instance property directly or by passing FALSE as the value of
the send_etag key in the $params array that the Create method accepts.
