### PR TITLE
Add the ability to save data to a stream.

### DIFF
--- a/lib/OpenCloud/ObjectStore/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/DataObject.php
@@ -493,7 +493,7 @@ class DataObject extends ObjectStore
     public function SaveToStream($resource)
     {
         if (!is_resource($resource)) {
-            throw new \Exceptions(
+            throw new \Exceptions\ObjectError(
                 Lang::translate("Resource argument not a valid PHP resource."
              ));
         }


### PR DESCRIPTION
- Useful when we don't want to save to a filename directly but stream
  it (this was something available in php-cloudfiles as well).
