### PR TITLE
Fixed: Can’t add a rule to the access list of the load balancer

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Resources/Access.php
+++ b/lib/OpenCloud/LoadBalancer/Resources/Access.php
@@ -27,4 +27,22 @@ class Access extends SubResource
         $this->NoUpdate(); 
     }
 
+    /**
+     * returns the JSON document's object for creating the subresource
+     *
+     * The value `$_create_keys` should be an array of names of data items
+     * that can be used in the creation of the object.
+     *
+     * @return \stdClass;
+     */
+    protected function CreateJson()
+    {
+        $object = new \stdClass();
+        $rule = new \stdClass();
+        foreach ($this->_create_keys as $item) {
+            $rule->$item = $this->$item;
+        }
+        $object->{$this->JsonName()} = array($rule);
+        return $object;
+    }
 }

--- a/tests/OpenCloud/Tests/LoadBalancerTest.php
+++ b/tests/OpenCloud/Tests/LoadBalancerTest.php
@@ -32,6 +32,9 @@ class MySubResource extends \OpenCloud\LoadBalancer\Resources\SubResource {
 		return parent::UpdateJson($params);
 	}
 }
+class MyAccess extends \OpenCloud\LoadBalancer\Resources\Access {
+    public function CreateJson() { return parent::CreateJson(); }
+}
 
 class LoadBalancerTest extends \PHPUnit_Framework_TestCase
 {
@@ -203,6 +206,13 @@ class LoadBalancerTest extends \PHPUnit_Framework_TestCase
 				'loadbalancers/123/accesslist',
 			$lb->Access()->Url()
 		);
+
+        $access = new MyAccess($lb, array('type' => 'DENY', 'address' => '127.0.0.1'));
+        $json = json_encode($access->CreateJson());
+        $this->assertEquals(
+            '{"accessList":[{"type":"DENY","address":"127.0.0.1"}]}',
+            $json
+        );
 	}
 	public function testAccessList() {
 		$lb = $this->service->LoadBalancer();


### PR DESCRIPTION
Fixed #150
