### PR TITLE
Fixed Collection::count() always returning 0

### DIFF
--- a/lib/OpenCloud/Common/Collection.php
+++ b/lib/OpenCloud/Common/Collection.php
@@ -78,7 +78,7 @@ class Collection extends Base
 
     public function count()
     {
-        return count($this->itemList);
+        return count($this->itemlist);
     }
 
     /**


### PR DESCRIPTION
Wrong member variable (fixes #157)
