### PR TITLE
Update RAXSDK_VERSION in Globals.php

### DIFF
--- a/lib/OpenCloud/Globals.php
+++ b/lib/OpenCloud/Globals.php
@@ -145,7 +145,7 @@ if (!defined('RAXSDK_SSL_VERIFYPEER'))
 //define('RAXSDK_CACERTPEM', __DIR__ . DIRECTORY_SEPARATOR . 'cacert.pem');
 
 /* these should not be overridden */
-define('RAXSDK_VERSION', '1.5.9');
+define('RAXSDK_VERSION', '1.5.10');
 define('RAXSDK_USER_AGENT', 'php-opencloud/'.RAXSDK_VERSION.' (Rackspace)');
 define('RAXSDK_ERROR', 'Error:');
 define('RAXSDK_FATAL', 'FATAL ERROR:');


### PR DESCRIPTION
Seems the version bump didn't get run before the last release. Not a big deal, but kind of surprised me when debugging and seeing the useragent show the previous version.
