### PR TITLE
Added tar as available type for archive extraction on DataObjects

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -320,9 +320,9 @@ class DataObject extends AbstractStorageObject
         $extractArchiveUrlArg = '';
         
         if ($extractArchive) {
-            if ($extractArchive !== "tar.gz" && $extractArchive !== "tar.bz2") {
+            if ($extractArchive !== "tar" && $extractArchive !== "tar.gz" && $extractArchive !== "tar.bz2") {
                 throw new Exceptions\ObjectError(
-                    "Extract Archive only supports tar.gz and tar.bz2"
+                    "Extract Archive only supports tar, tar.gz or tar.bz2"
                 );
             } else {
                 $extractArchiveUrlArg = "?extract-archive=" . $extractArchive;


### PR DESCRIPTION
Per the documentation -- http://docs.rackspace.com/files/api/v1/cf-devguide/content/Extract_Archive-d1e2338.html -- uncompressed tar files are also available for extraction; This pull request adds the raw tar extension to the extract archive type check in the DataObject create method.
