### PR TITLE
Only load Autoload.php if ClassLoader does not already exist

### DIFF
--- a/lib/php-opencloud.php
+++ b/lib/php-opencloud.php
@@ -5,7 +5,10 @@
  * @copyright 2013 Rackspace Hosting, Inc.
  * @license http://www.apache.org/licenses/LICENSE-2.0
  */
-require_once(__DIR__ . '/Autoload.php');
+
+if (!class_exists('ClassLoader')) {
+  require_once(__DIR__ . '/Autoload.php');
+}
 require_once(__DIR__ . '/OpenCloud/Globals.php');
 
 $classLoader = new ClassLoader;


### PR DESCRIPTION
Autoload.php  appears to be a universal autoloader. If it isn't, it should probably be namespaced. If it is, then we should check and see if the ClassLoader class already exists to reduce the chance of conflicting with other projects.
