### PR TITLE
Update docblock in DataObject class to reflect correct return value

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -254,7 +254,7 @@ class DataObject extends AbstractStorageObject
      *      'name' and 'content_type' of the object
      * @param string $filename if provided, then the object is loaded from the
      *      specified file
-     * @return boolean
+     * @return \OpenCloud\Common\Request\Response\Http
      * @throws CreateUpdateError
      */
     public function create($params = array(), $filename = null, $extractArchive = null)


### PR DESCRIPTION
In my use of the `create()` method, it doesn't return a boolean but instead returns an instance of `OpenCloud\Common\Request\Response\Http`.
