### PR TITLE
HOWTO.md link is broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,20 @@ efforts. Here are a few general guidelines to follow:
 
 If you submit code, please add your name and email address to the
 CONTRIBUTORS file.
+
+Test Instructions
+-----------------
+
+### Install Composer
+curl -sS https://getcomposer.org/installer | php
+
+### Install dependencies
+php composer.phar install
+
+### Run unit tests
+phpunit
+
+### (If necessary) run the full suite of acceptance tests
+1. Make sure your [variables-order](http://www.php.net/manual/en/ini.core.php#ini.variables-order) is set to "EGCRS"
+2. Set your *PHP_OpenCloud_USERNAME* and *PHP_OpenCloud_API_KEY* variables
+3. Run `php tests/OpenCloud/Smoke/Runner.php`

--- a/README.md
+++ b/README.md
@@ -69,14 +69,7 @@ The source for the "Getting Started with
 There is a complete (auto-generated) API reference manual in the
 docs/api directory. Start with docs/api/index.html.
 
-See the [HOWTO.md](https://github.com/rackspace/php-opencloud/blob/master/HOWTO.md) file for instructions on
-regenerating the documentation and running tests.
-
-See the [smoketest.php](https://github.com/rackspace/php-opencloud/blob/master/smoketest.php) file for some
-simple, working examples. This is a test we run before builds to ensure that all
-the core functionality is still working after code changes.
-
-The [samples/](https://github.com/rackspace/php-opencloud/tree/master/samples/) directory has a collection
+The [samples/](https://github.com/rackspace/php-opencloud/tree/master/docs/samples/) directory has a collection
 of tested, working sample code. Note that these may create objects in your cloud
 for which you could be charged.
 


### PR DESCRIPTION
Are the "instructions on regenerating the documentation and running tests" somewhere else?
