### PR TITLE
Fixed HMAC body for temp URL generation

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -169,7 +169,8 @@ class DataObject extends AbstractResource
         // @codeCoverageIgnoreEnd
 
         $url  = $this->getUrl();
-        $body = sprintf("%s\n%d\n%s", $method, $expiry, $url->getPath());
+        $urlPath = urldecode($url->getPath());
+        $body = sprintf("%s\n%d\n%s", $method, $expiry, $urlPath);
         $hash = hash_hmac('sha1', $body, $secret);
 
         return sprintf('%s?temp_url_sig=%s&temp_url_expires=%d', $url, $hash, $expiry);


### PR DESCRIPTION
When generating temporary URLs, the URL path included in the HMAC body has to be url decoded, or the HMAC digest won't match the one on the server side (at least, not with Rackspace). This issue manifests itself if you have a container or file that has a space character in it.

This is a regression in 1.7.0 (temp URLs work fine in 1.6.0)

https://github.com/rackspace/php-opencloud/issues/204
