### PR TITLE
Not sending Content-Type on requests

### DIFF
--- a/lib/OpenCloud/Common/PersistentObject.php
+++ b/lib/OpenCloud/Common/PersistentObject.php
@@ -192,7 +192,7 @@ abstract class PersistentObject extends Base
         $createUrl = $this->createUrl();
 
         // send the request
-        $response = $this->getClient()->post($createUrl, array(), $json)
+        $response = $this->getClient()->post($createUrl, array('Content-Type' => 'application/json'), $json)
             ->setExceptionHandler(array(
                 201 => array(
                     'allow'    => true,
@@ -438,7 +438,7 @@ abstract class PersistentObject extends Base
         $url = $this->url('action');
 
         // POST the message
-        return $this->getClient()->post($url, array(), $json)->send();
+        return $this->getClient()->post($url, array('Content-Type' => 'application/json'), $json)->send();
     }
 
      /**


### PR DESCRIPTION
You find interesting things while intercepting via proxies...

php-opencloud is sending Content-Type on authentication (see [here](https://github.com/rackspace/php-opencloud/blob/7d2687b7fecf4d81198563a634b830a302c2cead/lib/OpenCloud/OpenStack.php#L277)), but not on other services.

I guess OpenRepose is being lenient and assuming JSON rather than XML.  It is more correct (and less likely to cause problems with proxies or other middleware) if you send the Content-Type, though.

I don't think this PR covers all the necessary posts.  Does each post need to be changed, or is it possible to change in the HTTP client?
