### PR TITLE
Add request message body and headers to the BadResponseException

### DIFF
--- a/lib/OpenCloud/Common/Http/Exception/BadResponseException.php
+++ b/lib/OpenCloud/Common/Http/Exception/BadResponseException.php
@@ -36,7 +36,9 @@ class BadResponseException extends GuzzleBadResponseException
                 '[reason phrase] ' . $response->getReasonPhrase(),
                 '[message] ' . (string) $response->getBody(),
                 '[method] ' . $request->getMethod(),
-                '[url] ' . $request->getUrl()
+                '[url] ' . $request->getUrl(),
+                '[request message] ' . (string) $request->getBody(),
+                '[request raw headers] ' . (string) $request->getRawHeaders(),
             ));
 
         $e = new $class($message);


### PR DESCRIPTION
For a user debugging their malformed request, the request message body and headers may be valuable.
