### PR TITLE
Readd tenant support, and fix related unit test

### DIFF
--- a/lib/OpenCloud/OpenStack.php
+++ b/lib/OpenCloud/OpenStack.php
@@ -231,11 +231,23 @@ class OpenStack extends Client
     {
         if (!empty($this->secret['username']) && !empty($this->secret['password'])) {
            
-            return json_encode(array(
+            $credentials = array(
                 'auth' => array(
                     'passwordCredentials' => $this->secret
                 )
-            ));
+            );
+
+            if( !empty($credentials['auth']['passwordCredentials']['tenantName']) ) {
+                $credentials['auth']['tenantName'] = $credentials['auth']['passwordCredentials']['tenantName'];
+                unset($credentials['auth']['passwordCredentials']['tenantName']);
+            } 
+            
+            if( !empty($credentials['auth']['passwordCredentials']['tenantId']) ) {
+                $credentials['auth']['tenantId'] = $credentials['auth']['passwordCredentials']['tenantId'];
+                unset($credentials['auth']['passwordCredentials']['tenantId']);
+            }
+
+            return json_encode($credentials);
             
         } else {
             throw new Exceptions\CredentialError(

--- a/tests/OpenCloud/Tests/OpenStackTest.php
+++ b/tests/OpenCloud/Tests/OpenStackTest.php
@@ -36,7 +36,7 @@ class OpenStackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->credentials, $client->getSecret());
 
         $this->assertEquals(
-            json_encode(array('auth' => array('passwordCredentials' => $this->credentials))), 
+            json_encode(array('auth' => array('passwordCredentials' => array('username' => 'foo', 'password' => 'bar'), 'tenantName' => 'baz'))), 
             $client->getCredentials()
         );
     }


### PR DESCRIPTION
With version 1.7.0, proper support for tenants was lost, making php-openclouds not very useful for non-rackspace clouds. With this change, tenant name and/or tenant id is place on the same level with passwordCredentials, per the keystone API, restoring openstack compatibility.

The associated unit test was also wrong, and did not properly simulate an actual conversation with keystone. This has been fixed as well.
