### PR TITLE
Fix ObjectStore being incompatible with CDN-less setups

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/Container.php
+++ b/lib/OpenCloud/ObjectStore/Resource/Container.php
@@ -256,9 +256,8 @@ class Container extends AbstractContainer
         $this->setMetadata($headers, true);
         
         try {
-            $cdnService = $this->getService()->getCDNService();
 
-            if ($cdnService) {
+            if (null !== ($cdnService = $this->getService()->getCDNService())) {
                 $cdn = new CDNContainer($this->getService()->getCDNService());
                 $cdn->setName($this->name);
                 
@@ -268,9 +267,6 @@ class Container extends AbstractContainer
                     $this->cdn = $cdn;
                     $this->cdn->setMetadata($response->getHeaders(), true);
                 }
-            }
-            else {
-                $this->cdn = null;
             }
             
         } catch (ClientErrorResponseException $e) {}   


### PR DESCRIPTION
Most OpenStack deployments do not have a CDN service, but OpenCloud/ObjectStore/Resource/Container::refresh insists on updating its data from it.

Made the refresh path for CDN optional, depending on whether there is a CDN service present.
