### PR TITLE
Fixes to DirectorySync.php that prevent errors

### DIFF
--- a/lib/OpenCloud/ObjectStore/Upload/DirectorySync.php
+++ b/lib/OpenCloud/ObjectStore/Upload/DirectorySync.php
@@ -118,7 +118,7 @@ class DirectorySync
                     $requests[] = $this->container->getClient()->put(
                         $remoteFile->getUrl(),
                         $remoteFile->getMetadata()->toArray(),
-                        $entityBody
+                        (string) $entityBody
                     );
                 }
 
@@ -127,7 +127,7 @@ class DirectorySync
                 $url = clone $this->container->getUrl();
                 $url->addPath($filename);
 
-                $requests[] = $this->container->getClient()->put($url, array(), $entityBody);
+                $requests[] = $this->container->getClient()->put($url, array(), (string) $entityBody);
             }
         }
 


### PR DESCRIPTION
Fixed some errors I encountered when using the container class's new uploadDirectory function. My fixes are in DirectorySync.php's execute function.
1. DirectorySync.php would attempt to fopen files for reading without checking if file is readable. Added a quick check with is_readable()
2. The $requestBody object was being passed to the $requests array, which prevented garbage collection and prevented the file stream for $requestBody from being closed. When adding many files (~100) this could cause a PHP error due to too many files being open. Cast to string before adding to array instead, allowing files to be closed.
