### PR TITLE
missing closing parenthesis on example using sprintf

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -147,7 +147,7 @@ try {
     $statusCode   = $e->getResponse()->getStatusCode();
     $headers      = $e->getResponse()->getHeaderLines();
 
-    echo sprintf('Status: %s\nBody: %s\nHeaders: %s', $statusCode, $responseBody, implode(', ', $headers));
+    echo sprintf("Status: %s\nBody: %s\nHeaders: %s", $statusCode, $responseBody, implode(', ', $headers));
 }
 ```
 


### PR DESCRIPTION
Hello! 

While following the examples, I noticed a missing parenthesis on the example code in the getting started doc. Thanks! 
- Martin
  martin@mbs3.org / martin.smith@rackspace.com
