### PR TITLE
Added $mode parameter to fopen call on docs.

### DIFF
--- a/docs/userguide/ObjectStore/Storage/Object.md
+++ b/docs/userguide/ObjectStore/Storage/Object.md
@@ -237,7 +237,7 @@ into a particular container:
 ```php
 use OpenCloud\ObjectStore\Constants\UrlType;
 
-$service->bulkExtract('container_1', fopen('/home/jamie/files.tar.gz'), UrlType::TAR_GZ);
+$service->bulkExtract('container_1', fopen('/home/jamie/files.tar.gz','r'), UrlType::TAR_GZ);
 ```
 
 You can also omit the container name (i.e. provide an empty string as the first argument). If you do this, the API will


### PR DESCRIPTION
Whilst trying to implement the `bulkExtract` request, a colleague and I noticed the documentation was missing a required parameter in the documentation, which I've now added in.
