### PR TITLE
Fixing ObjectStore DataObject update() function so that metadata is sent properly.

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -303,7 +303,7 @@ class DataObject extends AbstractResource
 
     public function update($params = array())
     {
-        return $this->container->uploadObject($this->name, $this->content, $this->metadata->toArray());
+        return $this->container->uploadObject($this->name, $this->content, self::stockHeaders($this->metadata->toArray()));
     }
 
     /**


### PR DESCRIPTION
Without converting the metadata array to use the stockHeaders function, all metadata is ignored on Rackspace.
