### PR TITLE
Changing Metadata array to use proper header syntax in DataObject's update().

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -303,7 +303,7 @@ class DataObject extends AbstractResource
 
     public function update($params = array())
     {
-        return $this->container->uploadObject($this->name, $this->content, $this->metadata->toArray());
+        return $this->container->uploadObject($this->name, $this->content, self::stockHeaders($this->metadata->toArray()));
     }
 
     /**


### PR DESCRIPTION
Needed to convert the metadata names in to something like X-Meta-Object-... otherwise the metadata will be ignored by Rackspace Cloud Files.

AbstractResource's saveMetadata works this way already.
