### PR TITLE
Fixed lists ignoring filter arguments

### DIFF
--- a/lib/OpenCloud/Common/Collection/PaginatedIterator.php
+++ b/lib/OpenCloud/Common/Collection/PaginatedIterator.php
@@ -254,7 +254,7 @@ class PaginatedIterator extends ResourceIterator implements Iterator
         if (!$url = $this->nextUrl) {
 
             $url = clone $this->getOption('baseUrl');
-            $query = array();
+            $query = $url->getQuery();
 
             if (isset($this->currentMarker)) {
                 $query[static::MARKER] = $this->currentMarker;


### PR DESCRIPTION
Copy URL's query string in PaginatedIterator, so any filters set by methods like objectList(), recordList(), etc. are copied as well.
Fixes issue #267
