### PR TITLE
DataObject->contentLength and PaginatedIterator->shouldAppend

### DIFF
--- a/lib/OpenCloud/Common/Collection/PaginatedIterator.php
+++ b/lib/OpenCloud/Common/Collection/PaginatedIterator.php
@@ -172,7 +172,7 @@ class PaginatedIterator extends ResourceIterator implements Iterator
 
     protected function shouldAppend()
     {
-        return $this->currentMarker && $this->getOption('limit.page') % ($this->position + 1) == 0;
+        return $this->currentMarker && (($this->position + 1) % $this->getOption('limit.page') == 0);
     }
 
     /**

--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -256,7 +256,7 @@ class DataObject extends AbstractResource
      */
     public function getContentLength()
     {
-        return $this->contentLength ?: $this->content->getContentLength();
+        return $this->contentLength !== null ? $this->contentLength : $this->content->getContentLength();
     }
 
     /**


### PR DESCRIPTION
DataObject:
Don't fetch contentLength from content for partial objects when the actual size of the object is 0 (zero) bytes

PaginatedIterator:
Collection seems to be appending elements when not necessary. Seems the 'shouldAppend' checks if the current page is divisible by the new (current +1) position.
For a 'page,limit' of 100 this check returns 'TRUE' for positions like 1, 2, 4 ...
IMO the check should be the other way around, so the new position is divisible by the 'limit.page'.
