### PR TITLE
Support providing cloud-init executable code during server create

### DIFF
--- a/lib/OpenCloud/Compute/Resource/Server.php
+++ b/lib/OpenCloud/Compute/Resource/Server.php
@@ -154,6 +154,12 @@ class Server extends PersistentObject
     private $flavorRef;
 
     /**
+     * Cloud-init boot executable code
+     * @var string
+     */
+    public $user_data;
+
+    /**
      * Creates a new Server object and associates it with a Compute service
      *
      * @param mixed $info
@@ -642,6 +648,11 @@ class Server extends PersistentObject
             } elseif ($this->keypair instanceof Keypair && $this->keypair->getName()) {
                 $server->key_name = $this->keypair->getName();
             }
+        }
+
+        // Cloud-init executable
+        if (!empty($this->user_data)) {
+           $server->user_data = $this->user_data;
         }
 
         return (object) array('server' => $server);

--- a/tests/OpenCloud/Tests/Compute/Resource/ServerTest.php
+++ b/tests/OpenCloud/Tests/Compute/Resource/ServerTest.php
@@ -270,6 +270,15 @@ class ServerTest extends ComputeTestCase
         $this->assertEquals(
             '/tmp/hello.txt', $obj->server->personality[0]->path);
     }
+
+    public function test_Create_UserData()
+    {
+        $new = new PublicServer($this->service);
+        $new->user_data = 'foo';
+        $obj = $new->createJson();
+
+        $this->assertEquals('foo', $obj->server->user_data);
+    }
     
     public function test_Image_Schedule()
     {


### PR DESCRIPTION
This commit adds support for cloud-init, which allows code to be executed on first boot of an instance.
