### PR TITLE
Require cURL extension for PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require": {
         "php" : ">=5.3.3",
+        "ext-curl" : "*",
         "guzzle/http" : "3.8.*@dev"
     },
     "require-dev" : {


### PR DESCRIPTION
cURL extension for PHP is required according to README.md.
