### PR TITLE
Add support for retrieving hard-limits from Nova

### DIFF
--- a/lib/OpenCloud/Compute/Service.php
+++ b/lib/OpenCloud/Compute/Service.php
@@ -192,4 +192,16 @@ class Service extends NovaService
     {
         return $this->resourceList('KeyPair', null, $this);
     }
+
+    /**
+     * Retrieve the (read-only) hard-limits for the current tenant.
+     *
+     * @return stdClass
+     */
+    public function limits()
+    {
+        $url = $this->url('limits');
+        return json_decode($this->request($url)->httpBody())->limits;
+    }
+
 }


### PR DESCRIPTION
This is a redo of #189, because I'm pretty sure the limits this API request retrieves are distinct from those of AbstractTransfer. If it turns out that there is a way to retrieve these limits currently then please let me know what it is ;)
