### PR TITLE
Proposal to fix the user creation issue with OpenStack

### DIFF
--- a/lib/OpenCloud/Common/Resource/PersistentResource.php
+++ b/lib/OpenCloud/Common/Resource/PersistentResource.php
@@ -202,7 +202,7 @@ abstract class PersistentResource extends BaseResource
 
         foreach ($this->createKeys as $key) {
             if (null !== ($property = $this->getProperty($key))) {
-                $element->$key = $property;
+                $element->{$this->getAlias($key)} = $property;
             }
         }
 
@@ -211,6 +211,22 @@ abstract class PersistentResource extends BaseResource
         }
 
         return (object) array($this->jsonName() => (object) $element);
+    }
+
+    /**
+     * Returns the alias configured for the given key. If no alias exists
+     * it returns the original key.
+     *
+     * @param  string $key
+     * @return string
+     */
+    protected function getAlias($key)
+    {
+        if (isset($this->aliases) && !empty($this->aliases) && in_array($key, $this->aliases)) {
+            return array_search($key, $this->aliases);
+        }
+
+        return $key;
     }
 
     /**

--- a/lib/OpenCloud/Identity/Resource/User.php
+++ b/lib/OpenCloud/Identity/Resource/User.php
@@ -55,10 +55,11 @@ class User extends PersistentObject
     /** @var string The string password for this user */
     private $password;
 
-    protected $createKeys = array('username', 'email', 'enabled');
+    protected $createKeys = array('username', 'email', 'enabled', 'password');
     protected $updateKeys = array('username', 'email', 'enabled', 'RAX-AUTH:defaultRegion', 'RAX-AUTH:domainId', 'id');
 
     protected $aliases = array(
+        'name'                   => 'username',
         'RAX-AUTH:defaultRegion' => 'defaultRegion',
         'RAX-AUTH:domainId'      => 'domainId',
         'OS-KSADM:password'      => 'password'


### PR DESCRIPTION
Hi,

the opencloud library does not send the right parameters to the OpenStack API according to the [API reference](http://api.openstack.org/api-ref-identity-v2.html#os-ksadm-admin-ext).

Here is what the library sends

``` json
{
    "user": {
        "username": "foo",
        "enabled": true,
        "email": "foo@bar.fr"
    }
}
```

but it should be 

``` json
{
    "user": {
        "name": "foo",
        "enabled": true,
        "email": "foo@bar.fr",
        "OS-KSADM:password": "secrete"
    }
}
```

This fix tries to solve two things:
- it replaces the keys of the payload by their aliases if they exist
- it change the key "username" to "name" by the aliasing system

I can provide test if you want but before I would like to know if I did it the right way or want to have some feedback before going further.

Thanks :)
