### PR TITLE
CatalogService does not initialize region if regionless = true

### DIFF
--- a/lib/OpenCloud/Common/Service/CatalogService.php
+++ b/lib/OpenCloud/Common/Service/CatalogService.php
@@ -59,7 +59,8 @@ abstract class CatalogService extends AbstractService
 
         $this->name = $name ?: static::DEFAULT_NAME;
 
-        if ($this->regionless !== true && !($this->region = $region)) {
+        $this->region = $region;
+        if ($this->regionless !== true && !$this->region) {
             throw new Exceptions\ServiceException(sprintf(
                 'The %s service must have a region set. You can either pass in a region string as an argument param, or'
                 . ' set a default region for your user account by executing User::setDefaultRegion and ::update().',


### PR DESCRIPTION
Regionless services, like DNS does not get initialized with region and fail on
Rackspace::dnsService
ServiceBuilder::factory
CatalogService::__construct
CatalogService::findEndpoint
CatalogItem::getEndpointFromRegion
line 139 with message
This service [cloudDNS] does not have access to the [] endpoint.
