### PR TITLE
Fix deleting PTR records

### DIFF
--- a/lib/OpenCloud/DNS/Resource/PtrRecord.php
+++ b/lib/OpenCloud/DNS/Resource/PtrRecord.php
@@ -113,7 +113,8 @@ class PtrRecord extends Record
         }
 
         $url = clone $this->getUrl();
-        $url->addPath('rdns')
+        $url->addPath('..')
+            ->normalizePath()
             ->addPath($this->link_rel)
             ->setQuery($params);
 


### PR DESCRIPTION
Deleting PTR records currently fails with a 404, this [correctly sends](http://docs.rackspace.com/cdns/api/v1.0/cdns-devguide/content/ReverseDNS-123457005.html) the DELETE request to the collection rather than the individual entity.

Before:

```
DELETE /v1.0/00000000/rdns/PTR-000000/rdns/cloudServersOpenStack?href=https%3A%2F%2Flon.servers.api.rackspacecloud.com%2Fv2%2F00000000%2Fservers%2F00000000-0000-0000-0000-000000000000&ip=a.b.c.d
```

After:

```
DELETE /v1.0/00000000/rdns/cloudServersOpenStack?href=https%3A%2F%2Flon.servers.api.rackspacecloud.com%2Fv2%2F00000000%2Fservers%2F00000000-0000-0000-0000-000000000000&ip=a.b.c.d
```
