### PR TITLE
Added PHP 5.6 and HHVM to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: php
 php:
+  - "5.6"
   - "5.5"
   - "5.4"
   - "5.3"
-  
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
 branches:
   only:
     - master


### PR DESCRIPTION
I saw that you recently removed HHVM. Why did you do that?

I put HHVM under `allow_failures` now so it wont break the build.
