### PR TITLE
Fixing regex to not assume presence of claim_id.

### DIFF
--- a/lib/OpenCloud/Queues/Resource/Message.php
+++ b/lib/OpenCloud/Queues/Resource/Message.php
@@ -78,7 +78,7 @@ class Message extends PersistentObject
     public function setHref($href)
     {
         // We have to extract the ID out of the Href. Nice...
-        preg_match('#.+/([\w\d]+)#', $href, $match);
+        preg_match('#.+/([\w]+)#', $href, $match);
         if (!empty($match)) {
             $this->setId($match[1]);
         }


### PR DESCRIPTION
If messages are retrieved via the `GET /v1/queues/{queue_name}/messages` API call, the messages' hrefs in the response do not contain a `claim_id` (see http://docs.rackspace.com/queues/api/v1.0/cq-devguide/content/GET_getMessages_v1_queues__queue_name__messages_message-operations.html#GET_getMessages_v1_queues__queue_name__messages_message-operations-Response).

So the regex should not assume that `claim_id` will always be present in the message href.
