### PR TITLE
Allow repopulation of objects with no logger set.

### DIFF
--- a/lib/OpenCloud/Common/Base.php
+++ b/lib/OpenCloud/Common/Base.php
@@ -244,7 +244,7 @@ abstract class Base
      * @param Log\LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(Log\LoggerInterface $logger)
+    public function setLogger(Log\LoggerInterface $logger = null)
     {
         $this->logger = $logger;
 

--- a/tests/OpenCloud/Tests/LoadBalancer/Resource/LoadBalancerTest.php
+++ b/tests/OpenCloud/Tests/LoadBalancer/Resource/LoadBalancerTest.php
@@ -343,4 +343,12 @@ class LoadBalancerTest extends LoadBalancerTestCase
 
         $this->assertEquals($health->type, 'CONNECT');
     }
+
+    public function testAddNodeToExistingLoadBalancer()
+    {
+        $lb = $this->loadBalancer;
+
+        $lb->addNode('2.2.2.2', 80);
+        $lb->addNodes();
+    }
 }


### PR DESCRIPTION
When new nodes are added to an existing load balancer using the [`addNode` method of the LoadBalancer class](https://github.com/rackspace/php-opencloud/blob/working/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php#L198-L238), no `logger` property is set for the new node objects (i.e. the `logger` property has the value `null`).

Subsequently, when the [`addNodes` method of the LoadBalancer class](https://github.com/rackspace/php-opencloud/blob/working/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php#L246-L261) is called, each node object is repopulated.

During this repopulation, the [`setProperty` method of the `Base` class](https://github.com/rackspace/php-opencloud/blob/working/lib/OpenCloud/Common/Base.php#L106-L133) is called with arguments `"logger"` and `null`. This, in turn, calls the [`setLogger` method of the `Base` class](https://github.com/rackspace/php-opencloud/blob/working/lib/OpenCloud/Common/Base.php#L248-L253) with the argument `null`. Since this argument has the type hint `OpenCloud\Common\LoggerInterface`, it fails with this error: `Argument 1 passed to OpenCloud\Common\Base::setLogger() must implement interface Psr\Log\LoggerInterface, null given`. 

This PR allows the argument to `setLogger` to be nullable, thereby allowing repopulation of objects that have no logger set.
