### PR TITLE
Fixing license.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP SDK for Rackspace/OpenStack APIs",
     "keywords": ["rackspace", "openstack", "opencloud", "swift", "nova"],
     "type": "library",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Jamie Hannaford",


### PR DESCRIPTION
This PR fixes the license in composer.json so it is Apache 2.0 (per https://github.com/rackspace/php-opencloud/blob/working/LICENSE and https://getcomposer.org/doc/04-schema.md#license).
