### PR TITLE
Only add the node if it is new.

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php
+++ b/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php
@@ -246,7 +246,11 @@ class LoadBalancer extends PersistentResource implements HasPtrRecordsInterface
         $requests = array();
 
         foreach ($this->nodes as $node) {
-            $requests[] = $this->getClient()->post($node->getUrl(), self::getJsonHeader(), $node->createJson());
+            // Only add the node if it is new
+            if (null === $node->getId()) {
+                $json = json_encode($node->createJson());
+                $requests[] = $this->getClient()->post($node->getUrl(), self::getJsonHeader(), $json);
+            }
         }
 
         return $this->getClient()->send($requests);


### PR DESCRIPTION
Steve | TapGen reported this error and stack trace (over email) when trying to add nodes to a load balancer:

```
PHP Fatal error:  Uncaught exception 'Guzzle\Http\Exception\MultiTransferException' with message 'Errors during multi transfer
(Guzzle\Http\Exception\ClientErrorResponseException) ./vendor/guzzle/http/Guzzle/Http/Exception/BadResponseException.php line 43

    Client error response
    [status code] 405
    [reason phrase] Method Not Allowed
    [url] https://ord.loadbalancers.api.rackspacecloud.com/v1.0/581276/loadbalancers/93479/nodes/705087

    #0 ./vendor/guzzle/http/Guzzle/Http/Message/Request.php(145): Guzzle\Http\Exception\BadResponseException::factory(Object(Guzzle\Http\Message\EntityEnclosingRequest), Object(Guzzle\Http\Message\Response))
    #1 [internal function]: Guzzle\Http\Message\Request::onRequestError(Object(Guzzle\Common\Event), 'request.error', Object(Symfony\Component\EventDispatcher\EventDispatcher))
    #2 ./vendor/symfony/event-dispatcher/Symfony/Component/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Guzzle\Common\Event), 'request.error', Object(Symfony\Component\EventDispatcher in /root/scripts/composer/vendor/guzzle/http/Guzzle/Http/Curl/CurlMulti.php on line 135
```

I was able to reproduce this error using a load balancer that already had nodes attached to it.

To fix it I added a check to `$loadBalancer->addNodes` so it only add nodes if they were new to the load balancer (i.e. they didn't have an ID).

Once I put this check in, however, I started getting a different error about wrong `Content-Type`. To fix this I had to wrap the return value from `$node->createJson()` with `json_encode`. Otherwise Guzzle sees the PHP array returned by `$node->createJson()` and sets the `Content-Type` to `application/x-www-form-urlencoded; charset=utf-8` (see Guzzle source code [here](https://github.com/guzzle/http/blob/master/Message/RequestFactory.php#L102),  [here](https://github.com/guzzle/http/blob/master/Message/RequestFactory.php#L111) and [here](https://github.com/guzzle/http/blob/master/Message/EntityEnclosingRequest.php#L239)).
