### PR TITLE
Store full tenant objects in exported credentials

### DIFF
--- a/lib/OpenCloud/OpenStack.php
+++ b/lib/OpenCloud/OpenStack.php
@@ -411,7 +411,7 @@ class OpenStack extends Client
         return array(
             'token'      => $this->getToken(),
             'expiration' => $this->getExpiration(),
-            'tenant'     => $this->getTenant(),
+            'tenantObj'  => $this->getTenantObject(),
             'catalog'    => $this->getCatalog()
         );
     }
@@ -430,8 +430,8 @@ class OpenStack extends Client
         if (!empty($values['expiration'])) {
             $this->setExpiration($values['expiration']);
         }
-        if (!empty($values['tenant'])) {
-            $this->setTenant($values['tenant']);
+        if (!empty($values['tenantObj'])) {
+            $this->setTenantObject($values['tenantObj']);
         }
         if (!empty($values['catalog'])) {
             $this->setCatalog($values['catalog']);


### PR DESCRIPTION
exportCredentials() was using the deprecated getTenant() method which
only returns a numeric tenant ID. When importCredentials() attempted to
re-import this using setTenant() it would re-query the tenant using a
HEAD request to the tenant object. This reduces the effectiveness of
credential caching as importing credentials requires an unconditional
HTTP request

Instead switch importCredentials()/exportCredentials() to use
getTenantObject()/setTenantObject() respectively. Change the cache key
from 'tenant' to 'tenantObj' to prevent errors when attempting to
import older credentials.
