### PR TITLE
Store full tenant objects in exported credentials

### DIFF
--- a/lib/OpenCloud/OpenStack.php
+++ b/lib/OpenCloud/OpenStack.php
@@ -411,7 +411,7 @@ class OpenStack extends Client
         return array(
             'token'      => $this->getToken(),
             'expiration' => $this->getExpiration(),
-            'tenant'     => $this->getTenant(),
+            'tenantObj'  => $this->getTenantObject(),
             'catalog'    => $this->getCatalog()
         );
     }
@@ -430,7 +430,12 @@ class OpenStack extends Client
         if (!empty($values['expiration'])) {
             $this->setExpiration($values['expiration']);
         }
-        if (!empty($values['tenant'])) {
+        if (!empty($values['tenantObj'])) {
+            $this->setTenantObject($values['tenantObj']);
+        }
+        else if (!empty($values['tenant']))
+        {
+            // Backwards compatibility with the previous credential format that only stored the tenant ID
             $this->setTenant($values['tenant']);
         }
         if (!empty($values['catalog'])) {

--- a/tests/OpenCloud/Tests/OpenStackTest.php
+++ b/tests/OpenCloud/Tests/OpenStackTest.php
@@ -134,10 +134,16 @@ class OpenStackTest extends \PHPUnit_Framework_TestCase
 
     public function test_Import_Credentials()
     {
+        $tenant = new \OpenCloud\Identity\Resource\Tenant($this->client->identityService());
+        $tenant->setId(654321);
+        $tenant->setName('{name}');
+        $tenant->setDescription('{description}');
+        $tenant->setEnabled(true);
+
         $this->client->importCredentials(array(
             'token'      => '{token}',
             'expiration' => '{expiration}',
-            'tenant'     => '{tenant}',
+            'tenantObj'  => $tenant,
             'catalog'    => array(
                 (object)array(
                     'endpoints' => array(
@@ -155,7 +161,12 @@ class OpenStackTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('{token}', $this->client->getToken());
         $this->assertEquals('{expiration}', $this->client->getExpiration());
-        $this->assertEquals('{tenant}', $this->client->getTenant());
+
+        $importedTenant = $this->client->getTenantObject();
+        $this->assertEquals($tenant->getId(), $importedTenant->getId());
+        $this->assertEquals($tenant->getName(), $importedTenant->getName());
+        $this->assertEquals($tenant->getDescription(), $importedTenant->getDescription());
+        $this->assertEquals($tenant->getEnabled(), $importedTenant->getEnabled());
     }
 
     public function test_Import_Credentials_Numeric_Tenant()


### PR DESCRIPTION
exportCredentials() was using the deprecated getTenant() method which
only returns a numeric tenant ID. When importCredentials() attempted to
re-import this using setTenant() it would re-query the tenant using a
HEAD request to the tenant object. This reduces the effectiveness of
credential caching as importing credentials requires an unconditional
HTTP request

Instead switch importCredentials()/exportCredentials() to use
getTenantObject()/setTenantObject() respectively. Change the cache key
from 'tenant' to 'tenantObj' to prevent errors when attempting to
import older credentials.
