### PR TITLE
Allow CORS headers to not have X-*-Meta-* prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**php-opencloud-fork**
+**php-opencloud**
 =============
 PHP SDK for OpenStack/Rackspace APIs
 

--- a/lib/OpenCloud/ObjectStore/Resource/AbstractResource.php
+++ b/lib/OpenCloud/ObjectStore/Resource/AbstractResource.php
@@ -127,8 +127,19 @@ abstract class AbstractResource extends Base
     public static function stockHeaders(array $headers)
     {
         $output = array();
+        $prefix = null;
+        $corsHeaders = array(
+            'Access-Control-Allow-Origin',
+            'Access-Control-Expose-Headers',
+            'Access-Control-Max-Age',
+            'Access-Control-Allow-Credentials',
+            'Access-Control-Allow-Methods',
+            'Access-Control-Allow-Headers'
+        );
         foreach ($headers as $header => $value) {
-            $prefix = self::GLOBAL_METADATA_PREFIX . '-' . static::METADATA_LABEL . '-Meta-';
+            if (!in_array($header, $corsHeaders)) {
+                $prefix = self::GLOBAL_METADATA_PREFIX . '-' . static::METADATA_LABEL . '-Meta-';
+            }
             $output[$prefix . $header] = $value;
         }
 


### PR DESCRIPTION
I don't know why this is set on all headers, but it doesn't work with how your system does things, therefore this at least allows CORS headers through.

Related to Issue #395
