### PR TITLE
Added a branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,10 @@
     "require-dev" : {
         "guzzle/guzzle": "~3.8",
         "satooshi/php-coveralls": "0.6.*@dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.11-dev"
+        }
     }
 }


### PR DESCRIPTION
The next version will be 1.11.0, right? This means people can ask for `1.11.*@dev`, or `~1.11*@dev` etc in composer, which is far, far more preferable to asking for `dev-master`.
