### PR TITLE
Removing detail switch as the corresponding HTTP API call doesn't exist.

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Service.php
+++ b/lib/OpenCloud/LoadBalancer/Service.php
@@ -44,7 +44,7 @@ class Service extends NovaService
      * Return a paginated collection of load balancers
      *
      * @param bool $detail If TRUE, all details are returned; otherwise, a
-     *                     minimal set (ID, name) is retrieved
+     *                     minimal set (ID, name) is retrieved [DEPRECATED]
      * @param array $filter Optional query params used for search
      * @return \OpenCloud\Common\Collection\PaginatedIterator
      */
@@ -52,9 +52,6 @@ class Service extends NovaService
     {
         $url = $this->getUrl();
         $url->addPath(Resource\LoadBalancer::resourceName());
-        if ($detail) {
-            $url->addPath('detail');
-        }
         $url->setQuery($filter);
 
         return $this->resourceList('LoadBalancer', $url);

--- a/samples/LoadBalancer/list-load-balancers.php
+++ b/samples/LoadBalancer/list-load-balancers.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright 2012-2014 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Pre-requisites:
+// * Prior to running this script, you must setup the following environment variables:
+//   * OS_AUTH_URL: Your Rackspace Cloud Authentication URL,
+//   * OS_USERNAME: Your Rackspace Cloud Account Username,
+//   * RAX_API_KEY:  Your Rackspace Cloud Account API KEY, and
+//   * OS_REGION_NAME: The Rackspace Cloud region you want to use
+//
+
+require __DIR__ . '/../../vendor/autoload.php';
+use OpenCloud\Rackspace;
+
+// 1. Instantiate an Rackspace client.
+$client = new Rackspace(getenv('OS_AUTH_URL'), array(
+    'username' => getenv('OS_USERNAME'),
+    'apiKey' => getenv('RAX_API_KEY')
+));
+
+// 2. Obtain an LoadBalancer service object from the client.
+$region = getenv('OS_REGION_NAME');
+$loadBalancerService = $client->loadBalancerService(null, $region);
+
+// 3. Get load balancers.
+$loadBalancers = $loadBalancerService->loadBalancerList();
+foreach ($loadBalancers as $loadBalancer) {
+    /** @var $loadBalancer OpenCloud\LoadBalancer\Resource\LoadBalancer **/
+    var_dump($loadBalancer);
+}


### PR DESCRIPTION
If [these lines of code](../blob/working/lib/OpenCloud/LoadBalancer/Service.php#L55-L57) are to be believed, then a long time ago in a galaxy far, far away there apparently existed _two_ HTTP API calls to retrieve a list of load balancers:
1. `GET /v1.0/{tenantId}/loadbalancers`, and
2. `GET /v1.0/{tenantId}/loadbalancers/detail`

The [API developer guide for Load Balancers](http://docs.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/GET_listLoadBalancers_v1.0__account__loadbalancers_load-balancers.html), however, only documents call 1 but not call 2. Live HTTP requests against the load balancers service corroborate the documentation. 

Unfortunately, as the `$detail` parameter on the `loadBalancerList` method defaults to `true`, the SDK defaults to making call 2 which results in an HTTP 404 response.

This PR:
- Marks the `$detail` parameter as deprecated.
- Always makes call 1, regardless of the value of the `$detail` argument, thereby preserving backwards compatibility in a reasonable manner (in my opinion).
