### PR TITLE
Security.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You must install this library through Composer:
 # Install Composer
 curl -sS https://getcomposer.org/installer | php
 
+# It's recommended that you verify the script source before installation
+# by using the following command
+curl -sS https://getcomposer.org/installer | less
+
 # Require php-opencloud as a dependency
 php composer.phar require rackspace/php-opencloud
 ```


### PR DESCRIPTION
Piping directly into PHP (or worse: "sudo bash", as seems to be the trend) is dangerous. A warning of some sort should be provided in the installation instructions.

The Composer website appears to provide no checksums or hashes for verifying that the source has not changed in transit.
Feel free to change the wording (it probably needs a little work) but in my opinion the README.md file should have a warning in place.

Here's an example of how dangerous even app-level code can be: http://www.slideshare.net/RichieSM/an-introduction-to-php-shells
