### PR TITLE
Fix to "create user" operation

### DIFF
--- a/lib/OpenCloud/Identity/Resource/User.php
+++ b/lib/OpenCloud/Identity/Resource/User.php
@@ -60,7 +60,7 @@ class User extends PersistentObject
     protected $updateKeys = array('username', 'email', 'enabled', 'RAX-AUTH:defaultRegion', 'RAX-AUTH:domainId', 'id');
 
     protected $aliases = array(
-        'name'               => 'username',
+        'name'                   => 'username',
         'RAX-AUTH:defaultRegion' => 'defaultRegion',
         'RAX-AUTH:domainId'      => 'domainId',
         'OS-KSADM:password'      => 'password'


### PR DESCRIPTION
The "create user" operation is different for Rackspace and OpenStack APIs: Rackspace requires a [`username`](http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/POST_addUser__v2.0_users_User_Calls.html) attribute, OpenStack requires a [`name`](http://developer.openstack.org/api-ref-identity-v2.html#admin-users) attribute. This PR differentiates between clients to make that happen. Should fix #410 
