### PR TITLE
Renaming performance1-1 flavor to general1-1

### DIFF
--- a/docs/userguide/Orchestration/USERGUIDE.md
+++ b/docs/userguide/Orchestration/USERGUIDE.md
@@ -169,7 +169,7 @@ This operation takes one parameter, an associative array, with the following key
 | `name` | Name of the stack | String. Must start with an alphabetic character, and must contain only alphanumeric, `_`, `-` or `.` characters | Yes | - | `simple-lamp-setup` |
 | `template` | Template contents | String. JSON or YAML | No, if `templateUrl` is specified | `null` | `heat_template_version: 2013-05-23\ndescription: LAMP server\n` |
 | `templateUrl` | URL of the template file | String. HTTP or HTTPS URL | No, if `template` is specified | `null` | `https://raw.githubusercontent.com/rackspace-orchestration-templates/lamp/master/lamp.yaml` |
-| `parameters` | Arguments to the template, based on the template's parameters. For example, see the parameters in [this template section](https://github.com/rackspace-orchestration-templates/lamp/blob/master/lamp.yaml#L22) | Associative array | No | `null` | `array('flavor_id' => 'performance1_1')` |
+| `parameters` | Arguments to the template, based on the template's parameters. For example, see the parameters in [this template section](https://github.com/rackspace-orchestration-templates/lamp/blob/master/lamp.yaml#L22) | Associative array | No | `null` | `array('flavor_id' => 'general1-1')` |
 
 #### Preview a stack from a template file
 
@@ -300,7 +300,7 @@ This operation takes one parameter, an associative array, with the following key
 | ---- | ----------- | --------- | --------- | ------------- | ------------- |
 | `template` | Template contents | String. JSON or YAML | No, if `templateUrl` is specified | `null` | `heat_template_version: 2013-05-23\ndescription: LAMP server\n` |
 | `templateUrl` | URL of template file | String. HTTP or HTTPS URL | No, if `template` is specified | `null` | `https://raw.githubusercontent.com/rackspace-orchestration-templates/lamp/master/lamp-updated.yaml` |
-| `parameters` | Arguments to the template, based on the template's parameters | Associative array | No | `null`| `array('flavor_id' => 'performance1_1')` |
+| `parameters` | Arguments to the template, based on the template's parameters | Associative array | No | `null`| `array('flavor_id' => 'general1-1')` |
 | `timeoutMins` | Duration, in minutes, after which stack update should time out | Integer | Yes | - | 5 |
 
 #### Update a stack from a template file

--- a/tests/OpenCloud/Tests/Orchestration/Resource/StackTest.php
+++ b/tests/OpenCloud/Tests/Orchestration/Resource/StackTest.php
@@ -41,7 +41,7 @@ class StackTest extends OrchestrationTestCase
             'name'        => 'foobar',
             'templateUrl' => 'https://github.com/ycombinator/drupal-multi/template.yml',
             'parameters'  => array(
-                'flavor_id' => 'performance1_1',
+                'flavor_id' => 'general1-1',
                 'db_name'   => 'drupaldb',
                 'db_user'   => 'drupaldbuser'
             ),
@@ -56,7 +56,7 @@ class StackTest extends OrchestrationTestCase
             'stack_name'   => 'foobar',
             'template_url' => 'https://github.com/ycombinator/drupal-multi/template.yml',
             'parameters'   => array(
-                'flavor_id' => 'performance1_1',
+                'flavor_id' => 'general1-1',
                 'db_name'   => 'drupaldb',
                 'db_user'   => 'drupaldbuser'
             ),
@@ -71,7 +71,7 @@ class StackTest extends OrchestrationTestCase
         $updateParams = array(
             'templateUrl' => 'https://github.com/ycombinator/drupal-multi/template.yml',
             'parameters'  => array(
-                'flavor_id' => 'performance1_1',
+                'flavor_id' => 'general1-1',
                 'db_name'   => 'drupaldb',
                 'db_user'   => 'drupalwebuser'
             ),
@@ -85,7 +85,7 @@ class StackTest extends OrchestrationTestCase
         $expectedObj = (object) array(
             'template_url' => 'https://github.com/ycombinator/drupal-multi/template.yml',
             'parameters'   => array(
-                'flavor_id' => 'performance1_1',
+                'flavor_id' => 'general1-1',
                 'db_name'   => 'drupaldb',
                 'db_user'   => 'drupalwebuser'
             ),


### PR DESCRIPTION
Rackspace is phasing out the performance flavor class in favor of a general flavor class and other specialized flavor classes. This PR replaces all mentions of performance flavor IDs in the codebase with their equivalent general flavor IDs.
