### PR TITLE
Unsmoke suspend rescue

### DIFF
--- a/tests/OpenCloud/Smoke/Unit/Compute.php
+++ b/tests/OpenCloud/Smoke/Unit/Compute.php
@@ -166,30 +166,6 @@ class Compute extends AbstractUnit implements UnitInterface
         }
 
         sleep(3);
-
-        // Suspend
-        $this->step('Suspend the server');
-        $server->suspend();
-        $server->waitFor('ACTIVE', 120, $this->getWaiterCallback());
-
-        if ($server->status() == 'ERROR') {
-            $this->stepInfo("Server suspension failed with ERROR\n");
-            return false;
-        }
-
-        sleep(3);
-
-        // Resume
-        $this->step('Resume the server');
-        $server->resume();
-        $server->waitFor('ACTIVE', 120, $this->getWaiterCallback());
-
-        if ($server->status() == 'ERROR') {
-            $this->stepInfo("Server resuming failed with ERROR\n");
-            return false;
-        }
-
-        sleep(3);
         
         // Attach volume
         $this->step('Attach the volume');


### PR DESCRIPTION
Currently the Compute smoke tests test suspend and rescue operations. These smoke tests use an `OpenCloud\Rackspace` client (as opposed to an `OpenCloud\OpenStack` client). This client tests against the Rackspace Public Cloud which currently does not support suspend and rescue operations on the Compute service. Consequently, the smoke tests fail.

This PR removes the suspend and rescue tests from the smoke tests, allowing them to pass again.
