### PR TITLE
Update Service.php - constant value a typo?

### DIFF
--- a/lib/OpenCloud/Common/Constants/Service.php
+++ b/lib/OpenCloud/Common/Constants/Service.php
@@ -19,6 +19,6 @@ namespace OpenCloud\Common\Constants;
 
 class Service
 {
-    const INTERNAL_URL = 'publicUrl';
-    const PUBLIC_URL = 'internalUrl';
+    const INTERNAL_URL = 'internalUrl';
+    const PUBLIC_URL = 'publicUrl';
 }


### PR DESCRIPTION
Is this a a typo?  Intended to be used with \OpenCloud\ObjectStore\Service and other service constructors?  Also ambiguity of 'urlType' as used with archiveType is a little confusing.  Use of constants and better naming would make the ability to use service net (internal) endpoints more obvious.
