### PR TITLE
If versionless service URL is found but no supported service version is specified, use URL as-is

### DIFF
--- a/lib/OpenCloud/Common/Service/Endpoint.php
+++ b/lib/OpenCloud/Common/Service/Endpoint.php
@@ -18,7 +18,7 @@
 namespace OpenCloud\Common\Service;
 
 use Guzzle\Http\Url;
-use OpenCloud\Common\Http\Client;
+use OpenCloud\OpenStack;
 use OpenCloud\Common\Http\Message\Formatter;
 use OpenCloud\Common\Exceptions\UnsupportedVersionError;
 
@@ -48,10 +48,10 @@ class Endpoint
     /**
      * @param $object
      * @param string $supportedServiceVersion Service version supported by the SDK
-     * @param OpenCloud\Common\Http\Client $client HTTP client
+     * @param OpenCloud\OpenStack $client OpenStack client
      * @return Endpoint
      */
-    public static function factory($object, $supportedServiceVersion, Client $client)
+    public static function factory($object, $supportedServiceVersion, OpenStack $client)
     {
         $endpoint = new self();
 
@@ -130,10 +130,10 @@ class Endpoint
      *
      * @param string $url Endpoint URL
      * @param string $supportedServiceVersion Service version supported by the SDK
-     * @param OpenCloud\Common\Http\Client $client HTTP client
+     * @param OpenCloud\OpenStack $client OpenStack client
      * @return Guzzle/Http/Url Endpoint URL with version in it
      */
-    private function getVersionedUrl($url, $supportedServiceVersion, Client $client)
+    private function getVersionedUrl($url, $supportedServiceVersion, OpenStack $client)
     {
         $versionRegex = '/\/[vV][0-9][0-9\.]*/';
         if (1 === preg_match($versionRegex, $url)) {
@@ -141,8 +141,11 @@ class Endpoint
             return Url::factory($url);
         }
 
+        // If there is no version in $url but no $supportedServiceVersion
+        // is specified, just return $url as-is but log a warning
         if (is_null($supportedServiceVersion)) {
-            throw new UnsupportedVersionError('Service version supported by SDK not specified.');
+            $client->getLogger()->warning('Service version supported by SDK not specified. Using versionless service URL as-is, without negotiating version.');
+            return Url::factory($url);
         }
 
         // Make GET request to URL

--- a/tests/OpenCloud/Tests/Common/Service/EndpointTest.php
+++ b/tests/OpenCloud/Tests/Common/Service/EndpointTest.php
@@ -72,18 +72,18 @@ class EndpointTest extends OpenCloudTestCase
         );
     }
 
-    /**
-     * @expectedException OpenCloud\Common\Exceptions\UnsupportedVersionError
-     */
     public function testGetVersionedUrlWithVersionLessEndpointSupportedVersionNotSpecified()
     {
         $endpoint = new Endpoint();
 
-        $this->invokeMethod(
+        $expectedUrl = "http://hostport";
+        $actualUrl   = $this->invokeMethod(
             $endpoint,
             'getVersionedUrl',
-            array('http://hostport', null, $this->client)
+            array($expectedUrl, null, $this->client)
         );
+
+        $this->assertEquals($expectedUrl, $actualUrl);
     }
 
     public function testGetVersionedUrlWithVersionedEndpointUrl()


### PR DESCRIPTION
Fixes #492 
