### PR TITLE
Use Loadbalancer ID as marker

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
+++ b/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2012-2014 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCloud\LoadBalancer\Collection;
+
+use OpenCloud\Common\Collection\PaginatedIterator;
+
+/**
+ * This class sets custom defaults for LoadBalancers. Notably, it sets the marker to 'id' instead of 'name'.
+ *
+ * @package OpenCloud\LoadBalancer\Collection
+ */
+class LoadBalancerIterator extends PaginatedIterator {
+
+    /**
+     * Defaults for LoadBalancer request.
+     *
+     * @var array
+     */
+    protected $defaults = array(
+        // Collection limits
+        'limit.total'           => 10000,
+        'limit.page'            => 100,
+
+        // The "links" element key in response
+        'key.links'             => 'links',
+
+        // JSON structure
+        'key.collection'        => null,
+        'key.collectionElement' => null,
+
+        // The property used as the marker
+        'key.marker'            => 'id',
+
+        // Options for "next page" request
+        'request.method'        => 'GET',
+        'request.headers'       => array(),
+        'request.body'          => null,
+        'request.curlOptions'   => array()
+    );
+}

--- a/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
+++ b/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
@@ -26,7 +26,6 @@ use OpenCloud\Common\Collection\PaginatedIterator;
  */
 class LoadBalancerIterator extends PaginatedIterator
 {
-
     /**
      * Defaults for LoadBalancer request.
      *

--- a/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
+++ b/lib/OpenCloud/LoadBalancer/Collection/LoadBalancerIterator.php
@@ -24,7 +24,8 @@ use OpenCloud\Common\Collection\PaginatedIterator;
  *
  * @package OpenCloud\LoadBalancer\Collection
  */
-class LoadBalancerIterator extends PaginatedIterator {
+class LoadBalancerIterator extends PaginatedIterator
+{
 
     /**
      * Defaults for LoadBalancer request.

--- a/lib/OpenCloud/LoadBalancer/Service.php
+++ b/lib/OpenCloud/LoadBalancer/Service.php
@@ -18,6 +18,7 @@
 namespace OpenCloud\LoadBalancer;
 
 use OpenCloud\Common\Service\NovaService;
+use OpenCloud\LoadBalancer\Collection\LoadBalancerIterator;
 
 /**
  * Class that encapsulates the Rackspace Cloud Load Balancers service
@@ -28,6 +29,25 @@ class Service extends NovaService
 {
     const DEFAULT_NAME = 'cloudLoadBalancers';
     const DEFAULT_TYPE = 'rax:load-balancer';
+
+    /**
+     * Get a collection of LoadBalancer objects.
+     *
+     * @param string $class  The class name.
+     * @param string $url    (Optional) The url where the collection can be found. Defaults to null.
+     * @param string $parent (Optional) The parent class. Defaults to null.
+     * @param array  $data   (Optional) Data to include with the collection. Defaults to null.
+     * @return \OpenCloud\LoadBalancer\Collection\LoadBalancerIterator
+     */
+    public function collection($class, $url = null, $parent = null, $data = null)
+    {
+        $options            = $this->makeResourceIteratorOptions($this->resolveResourceClass($class));
+        $options['baseUrl'] = $url;
+
+        $parent = $parent ?: $this;
+
+        return LoadBalancerIterator::factory($parent, $options, $data);
+    }
 
     /**
      * Return a Load Balancer


### PR DESCRIPTION
### Summary

Have Loadbalancer service use the loadbalancer ID as a marker instead of the loadbalancer name.

### Approach

* Create `\OpenCloud\LoadBalancer\Collection\LoadBalancerIterator` class.
* Override the `collection()` method from the `AbstractService` method in `\OpenCloud\LoadBalancer\Service` class.

This is done in a similar manner to the `DnsIterator` class.

Fixes #502.

### Risk
- [x] Low

PR is this risk because we're keeping the existing `PaginatedIterator` functionality, and only changing the defaults.

### Tests
- [ ] Unit

**Smoke Test Instructions**
Calling `\OpenCloud\LoadBalancer\Service::loadBalancerList()->constructNextUrl()` should result in a URL with the loadbalancer ID being used as a marker instead of the laodbalancer name.