### PR TITLE
Disable Travis sudo for container based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - "5.3"
   - hhvm
 
+sudo: false
+
 matrix:
   allow_failures:
     - php: hhvm


### PR DESCRIPTION
Since you don't install any packages with sudo, you can use [Travis' containerized builds](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/). Builds start faster and life is awesome.
