### PR TITLE
Inject Logger in service when available in Client

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,11 @@ You can see in the first example that the constant `Rackspace::US_IDENTITY_ENDPO
 Rackspace's identity endpoint (`https://identity.api.rackspacecloud.com/v2.0/`). Another difference is that Rackspace
 uses API key for authentication, whereas OpenStack uses a generic password.
 
+#### 1.2 Logger injection
+As the `Rackspace` client extends the `OpenStack` client, they both support passing `$options` as an array via the constructor's third parameter. The options are passed as a config to the `Guzzle` client, but also allow to inject your own `Logger`. 
+
+Your logger should implement the `Psr\Log\LoggerInterface` [as defined in PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md). Example of a compatible logger is [`Monolog`](https://github.com/Seldaek/monolog). When the client does create a service, it will inject the logger if one is available.
+
 ### 2. Pick what service you want to use
 
 In this case, we want to use the Compute (Nova) service:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ uses API key for authentication, whereas OpenStack uses a generic password.
 #### 1.2 Logger injection
 As the `Rackspace` client extends the `OpenStack` client, they both support passing `$options` as an array via the constructor's third parameter. The options are passed as a config to the `Guzzle` client, but also allow to inject your own `Logger`. 
 
-Your logger should implement the `Psr\Log\LoggerInterface` [as defined in PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md). Example of a compatible logger is [`Monolog`](https://github.com/Seldaek/monolog). When the client does create a service, it will inject the logger if one is available.
+Prerequisities and usage example can be found in [the Clients userguide](/docs/userguide/Clients.md#12-logger-injection)
 
 ### 2. Pick what service you want to use
 

--- a/docs/userguide/Clients.md
+++ b/docs/userguide/Clients.md
@@ -11,7 +11,7 @@ Users have access to two types of client: `OpenCloud\OpenStack` and `OpenCloud\R
 3. `OpenCloud\OpenStack`
 4. `OpenCloud\Rackspace`
 
-## Initializing a client
+## 1. Initializing a client
 
 ### Rackspace
 
@@ -44,7 +44,29 @@ $client = new OpenStack('http://identity.my-openstack.com/v2.0', array(
 ));
 ```
 
-## Authentication
+#### 1.2 Logger injection
+As the `Rackspace` client extends the `OpenStack` client, they both support passing `$options` as an array via the constructor's third parameter. The options are passed as a config to the `Guzzle` client, but also allow to inject your own `Logger`. 
+
+Your logger should implement the `Psr\Log\LoggerInterface` [as defined in PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md). Example of a compatible logger is [`Monolog`](https://github.com/Seldaek/monolog). When the client does create a service, it will inject the logger if one is available.
+
+To inject a `LoggerInterface` compatible logger into a new `Client`:
+
+```php
+use Monolog\Logger;
+use OpenCloud\OpenStack;
+
+// create a log channel
+$log = new Logger('name');
+
+$client = new OpenStack('http://identity.my-openstack.com/v2.0', array(
+	'username' => 'foo',
+	'password' => 'bar'
+), array(
+	'logger' => $log,
+));
+```
+
+## 2. Authentication
 
 The Client does not automatically authenticate against the API on object creation - it waits for an API call. When this happens, it checks whether the current "token" has expired, and (re-)authenticates if necessary.
 
@@ -56,7 +78,7 @@ $client->authenticate();
 
 If the credentials are incorrect, a `401` error will be returned. If credentials are correct, a `200` status is returned with your Service Catalog.
 
-## Service Catalog
+## 3. Service Catalog
 
 The Service Catalog is returned on successful authentication, and is composed of all the different API services available to the current tenant. All of this functionality is encapsulated in the `Catalog` object, which allows you greater control and interactivity.
 
@@ -86,7 +108,7 @@ foreach ($catalog->getItems() as $catalogItem) {
 
 As you can see, you have access to each Service's name, type and list of endpoints. Each endpoint provides access to the specific region, along with its public and private endpoint URLs.
 
-## Default HTTP headers
+## 4. Default HTTP headers
 
 To set default HTTP headers:
 
@@ -94,6 +116,6 @@ To set default HTTP headers:
 $client->setDefaultOption('headers/X-Custom-Header', 'FooBar');
 ```
 
-## Other functionality
+## 5. Other functionality
 
 For a full list of functionality provided by Guzzle, please consult the [official documentation](http://docs.guzzlephp.org/en/latest/http-client/client.html).

--- a/lib/OpenCloud/Common/Base.php
+++ b/lib/OpenCloud/Common/Base.php
@@ -265,6 +265,14 @@ abstract class Base
     }
 
     /**
+     * @return bool
+     */
+    public function hasLogger()
+    {
+        return (null !== $this->logger);
+    }
+
+    /**
      * @deprecated
      */
     public function url($path = null, array $query = array())

--- a/lib/OpenCloud/Common/Service/CatalogService.php
+++ b/lib/OpenCloud/Common/Service/CatalogService.php
@@ -20,8 +20,10 @@ namespace OpenCloud\Common\Service;
 use Guzzle\Http\ClientInterface;
 use Guzzle\Http\Exception\BadResponseException;
 use Guzzle\Http\Url;
+use OpenCloud\Common\Base;
 use OpenCloud\Common\Exceptions;
 use OpenCloud\Common\Http\Message\Formatter;
+use OpenCloud\OpenStack;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 abstract class CatalogService extends AbstractService
@@ -71,6 +73,10 @@ abstract class CatalogService extends AbstractService
      */
     public function __construct(ClientInterface $client, $type = null, $name = null, $region = null, $urlType = null)
     {
+        if (($client instanceof Base || $client instanceof OpenStack) && $client->hasLogger()) {
+            $this->setLogger($client->getLogger());
+        }
+
         $this->setClient($client);
 
         $this->name = $name ? : static::DEFAULT_NAME;

--- a/lib/OpenCloud/Identity/Service.php
+++ b/lib/OpenCloud/Identity/Service.php
@@ -18,11 +18,13 @@
 namespace OpenCloud\Identity;
 
 use Guzzle\Http\ClientInterface;
+use OpenCloud\Common\Base;
 use OpenCloud\Common\Collection\PaginatedIterator;
 use OpenCloud\Common\Collection\ResourceIterator;
 use OpenCloud\Common\Http\Message\Formatter;
 use OpenCloud\Common\Service\AbstractService;
 use OpenCloud\Identity\Constants\User as UserConst;
+use OpenCloud\OpenStack;
 
 /**
  * Class responsible for working with Rackspace's Cloud Identity service.
@@ -40,6 +42,11 @@ class Service extends AbstractService
     public static function factory(ClientInterface $client)
     {
         $identity = new self();
+
+        if (($client instanceof Base || $client instanceof OpenStack) && $client->hasLogger()) {
+            $identity->setLogger($client->getLogger());
+        }
+
         $identity->setClient($client);
         $identity->setEndpoint(clone $client->getAuthUrl());
 

--- a/lib/OpenCloud/OpenStack.php
+++ b/lib/OpenCloud/OpenStack.php
@@ -79,6 +79,10 @@ class OpenStack extends Client
 
     public function __construct($url, array $secret, array $options = array())
     {
+        if (isset($options['logger']) && $options['logger'] instanceof LoggerInterface) {
+            $this->setLogger($options['logger']);
+        }
+
         $this->setSecret($secret);
         $this->setAuthUrl($url);
 
@@ -284,6 +288,14 @@ class OpenStack extends Client
         }
 
         return $this->logger;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasLogger()
+    {
+        return (null !== $this->logger);
     }
 
     /**

--- a/tests/OpenCloud/Tests/OpenStackTest.php
+++ b/tests/OpenCloud/Tests/OpenStackTest.php
@@ -184,4 +184,39 @@ class OpenStackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{expiration}', $this->client->getExpiration());
         $this->assertEquals($randomNumericTenant, $this->client->getTenant());
     }
+
+    public function testLoggerServiceInjection()
+    {
+        // Create a new client, pass stub via constructor options argument
+        $stubLogger = $this->getMock('Psr\Log\NullLogger');
+        $client = new OpenStack(Rackspace::US_IDENTITY_ENDPOINT, $this->credentials, array(
+            'logger' => $stubLogger,
+        ));
+        $client->addSubscriber(new MockSubscriber());
+
+        // Test all OpenStack factory methods on proper Logger service injection
+        $service = $client->objectStoreService('cloudFiles', 'DFW');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $service->getCdnService();
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->computeService('cloudServersOpenStack', 'DFW');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->orchestrationService(null, 'DFW');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->volumeService('cloudBlockStorage', 'DFW');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->identityService();
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->imageService('cloudImages', 'IAD');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+
+        $service = $client->networkingService(null, 'IAD');
+        $this->assertContains("Mock_NullLogger", get_class($service->getLogger()));
+    }
 }


### PR DESCRIPTION
Inject the `Logger` into the `Service` when the `Client` already has one.

Also allow passing a PSR-3 Logger via the `$options` array in the `OpenStack` constructor.

Added tests to ensure that all services that can be created using the `OpenStack` class do support this.