### PR TITLE
Update documentation for \OpenCloud\Compute\Service

### DIFF
--- a/lib/OpenCloud/Compute/Service.php
+++ b/lib/OpenCloud/Compute/Service.php
@@ -81,7 +81,7 @@ class Service extends NovaService
      *
      * @api
      * @param string $id - if specified, the server with the ID is retrieved
-     * @returns Resource\Server object
+     * @return Resource\Server object
      */
     public function server($id = null)
     {
@@ -102,7 +102,7 @@ class Service extends NovaService
      *                         not having all the information you need.
      * @param array   $filter  - a set of key/value pairs that is passed to the
      *                         servers list for filtering
-     * @returns \OpenCloud\Common\Collection\PaginatedIterator
+     * @return \OpenCloud\Common\Collection\PaginatedIterator
      */
     public function serverList($details = true, array $filter = array())
     {

--- a/lib/OpenCloud/Compute/Service.php
+++ b/lib/OpenCloud/Compute/Service.php
@@ -102,7 +102,7 @@ class Service extends NovaService
      *                         not having all the information you need.
      * @param array   $filter  - a set of key/value pairs that is passed to the
      *                         servers list for filtering
-     * @returns \OpenCloud\Common\Collection
+     * @returns \OpenCloud\Common\Collection\PaginatedIterator
      */
     public function serverList($details = true, array $filter = array())
     {
@@ -128,7 +128,7 @@ class Service extends NovaService
      *
      * @api
      * @param array $filter array of filter key/value pairs
-     * @return \OpenCloud\Common\Collection
+     * @return \OpenCloud\Common\Collection\PaginatedIterator
      */
     public function networkList($filter = array())
     {


### PR DESCRIPTION
### Summary

Update the documentation for some of the methods in the `\OpenCloud\Compute\Service` class.

### Approach

Modify the `@return` statements to the correct object type.

This mostly benefits those using IDEs that depend on `@return` to help with code-completion. However, it also benefits anyone reviewing the documentation inline, so that they know the correct object to expect.

### Risk
- [x] Low

PR is this risk because only documentation is being updated.

### Tests
- [ ] Unit
