### PR TITLE
Adding apigen config file

### DIFF
--- a/apigen.neon
+++ b/apigen.neon
@@ -1,0 +1,3 @@
+templateTheme: bootstrap
+
+accessLevels: [public]


### PR DESCRIPTION
This config file changes the theme to bootstrap from the default and only documents `public` methods and properties.