### PR TITLE
Added example of how to retrieve more than 10,000 objects

### DIFF
--- a/doc/services/object-store/objects.rst
+++ b/doc/services/object-store/objects.rst
@@ -201,7 +201,7 @@ the built-in paging which uses a 'marker' parameter to fetch the next page of da
             break;
         }
 
-        while ($object = $objects->next()) {
+        foreach ($objects as $object) {
             /** @var $object OpenCloud\ObjectStore\Resource\DataObject **/
             $containerObjects[] = $object->getName();
             $count++;

--- a/doc/services/object-store/objects.rst
+++ b/doc/services/object-store/objects.rst
@@ -177,6 +177,42 @@ docs <http://docs.openstack.org/api/openstack-object-storage/1.0/content/list-ob
 `Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/list-objects.php>`_
 
 
+List over 10,000 objects
+------------------------
+
+To retrieve more than 10,000 objects (the default limit), you'll need to use
+the built-in paging which uses a 'marker' parameter to fetch the next page of data.
+
+.. code-block:: php
+
+    $containerObjects = array();
+    $marker = '';
+
+    while ($marker !== null) {
+        $params = array(
+            'marker' => $marker,
+        );
+
+        $objects = $container->objectList($params);
+        $total = $objects->count();
+        $count = 0;
+
+        if ($total == 0) {
+            break;
+        }
+
+        while ($object = $objects->next()) {
+            /** @var $object OpenCloud\ObjectStore\Resource\DataObject **/
+            $containerObjects[] = $object->getName();
+            $count++;
+
+            $marker = ($count == $total) ? $object->getName() : null;
+        }
+    }
+
+`Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/list-objects-over-10000.php>`_
+
+
 Get object
 ----------
 

--- a/samples/ObjectStore/list-objects-over-10000.php
+++ b/samples/ObjectStore/list-objects-over-10000.php
@@ -52,7 +52,7 @@ while ($marker !== null) {
         break;
     }
 
-    while ($object = $objects->next()) {
+    foreach ($objects as $object) {
         /** @var $object OpenCloud\ObjectStore\Resource\DataObject **/
         $containerObjects[] = $object->getName();
         $count++;

--- a/samples/ObjectStore/list-objects-over-10000.php
+++ b/samples/ObjectStore/list-objects-over-10000.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2012-2014 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require dirname(__DIR__) . '/../vendor/autoload.php';
+
+use OpenCloud\Rackspace;
+
+// 1. Instantiate a Rackspace client. You can replace {authUrl} with
+// Rackspace::US_IDENTITY_ENDPOINT or similar
+$client = new Rackspace('{authUrl}', array(
+    'username' => '{username}',
+    'apiKey'   => '{apiKey}',
+));
+
+// 2. Obtain an Object Store service object from the client.
+$objectStoreService = $client->objectStoreService(null, '{region}');
+
+// 3. Get container.
+$container = $objectStoreService->getContainer('{containerName}');
+
+// 4. Get the list of objects
+$objects = $container->objectList();
+
+// 5. Create a list of all objects in the container
+$containerObjects = array();
+$marker = '';
+
+while ($marker !== null) {
+    $params = array(
+        'marker' => $marker,
+    );
+
+    $objects = $container->objectList($params);
+    $total = $objects->count();
+    $count = 0;
+
+    if ($total == 0) {
+        break;
+    }
+
+    while ($object = $objects->next()) {
+        /** @var $object OpenCloud\ObjectStore\Resource\DataObject **/
+        $containerObjects[] = $object->getName();
+        $count++;
+
+        $marker = ($count == $total) ? $object->getName() : null;
+    }
+}


### PR DESCRIPTION
Added an example of how to retrieve large data sets, based on http://stackoverflow.com/questions/18193501/rackspace-php-opencloud-filters-documentation-for-valid-objectlist-filters