### PR TITLE
Changed 'privateURL' to 'internalURL'

### DIFF
--- a/doc/services/object-store/migrating-containers.rst
+++ b/doc/services/object-store/migrating-containers.rst
@@ -68,12 +68,12 @@ You can access all this functionality by executing:
 
 
 It's advisable to do this process in a Cloud Server in one of the two
-regions you're migrating to/from. This allows you to use ``privateURL``
+regions you're migrating to/from. This allows you to use ``internalURL``
 as the third argument in the ``objectStoreService`` methods like this:
 
 .. code-block:: php
 
-  $client->objectStoreService('cloudFiles', 'IAD', 'privateURL');
+  $client->objectStoreService('cloudFiles', 'IAD', 'internalURL');
 
 
 This will ensure that traffic between your server and your new IAD


### PR DESCRIPTION
Object store documentation is displaying the incorrect url type. It says 'privateURL’ but it should be ‘internalURL’.