### PR TITLE
Allow port update() to modify security groups.

### DIFF
--- a/lib/OpenCloud/Networking/Resource/Port.php
+++ b/lib/OpenCloud/Networking/Resource/Port.php
@@ -78,7 +78,8 @@ class Port extends PersistentResource
 
     protected $updateKeys = array(
         'name',
-        'deviceId'
+        'deviceId',
+        'securityGroups'
     );
 
     /**


### PR DESCRIPTION
Allows the \OpenCloud\Networking\Resource\Port::update() method to affect security groups, as per API and library documentation. Currently the 'securityGroups' option is silently ignored. 

Additional keys are also omitted in the `$updateKeys` property, but they are beyond the scope of this pull-request:
```
adminStateUp
fixedIps
deviceOwner
```