### PR TITLE
Fix "create_server_with_keypair" sample

### DIFF
--- a/samples/Compute/create_server_with_keypair.php
+++ b/samples/Compute/create_server_with_keypair.php
@@ -40,7 +40,8 @@ try {
     $response = $server->create(array(
         'name'     => '{serverName}',
         'imageId'  => '{imageId}',
-        'flavorId' => '{flavorId}'
+        'flavorId' => '{flavorId}',
+        'keypair'  => '{keypairName}'
     ));
 } catch (BadResponseException $e) {
     echo $e->getResponse();


### PR DESCRIPTION
In the "create_server_with_keypair" sample, the keypair is missing.