### PR TITLE
hotfix – DataObject->setContentLength : Ensure int

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -265,7 +265,7 @@ class DataObject extends AbstractResource
     }
 
     /**
-     * @param $contentType mixed
+     * @param $contentLength mixed
      * @return $this
      */
     public function setContentLength($contentLength)

--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -265,7 +265,7 @@ class DataObject extends AbstractResource
     }
 
     /**
-     * @param $contentType int
+     * @param $contentType mixed
      * @return $this
      */
     public function setContentLength($contentLength)
@@ -276,7 +276,7 @@ class DataObject extends AbstractResource
     }
 
     /**
-     * @return int
+     * @return mixed
      */
     public function getContentLength()
     {


### PR DESCRIPTION
The type returned from `DataObject.contentLength` varies based on how the object
is populated. This change ensures that when 'setContentLength' is called
the property is set to the expected type (int).

It seems like this could be solved a number of ways, but this seemed like the  "silver bullet". At first glance it seems the problematic code is in the two `populate*` methods on the object. `populate` seems to be given a string for the [`$info->bytes`](https://github.com/rackspace/php-opencloud/blob/f080c2feffb64b544ecefa3d1b200b5c16a5a797/lib/OpenCloud/ObjectStore/Resource/DataObject.php#L119) and `populateFromResponse` is [explicitly cast to a string](https://github.com/rackspace/php-opencloud/blob/f080c2feffb64b544ecefa3d1b200b5c16a5a797/lib/OpenCloud/ObjectStore/Resource/DataObject.php#L147). These *could* be updated to cast to an integer but I thought I'd let someone more familiar with the library make the call.

Just let me know, and I would be happy to amend this pull request.

