### PR TITLE
override TempURL file names

### DIFF
--- a/doc/services/object-store/access.rst
+++ b/doc/services/object-store/access.rst
@@ -49,6 +49,17 @@ To allow PUT access for 1 hour:
 `Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/create-object-temporary-url.php>`_
 
 
+Override TempURL file names
+---------------------------
+
+Override tempURL file names simply by adding the filename parameter to the url:
+
+.. code-block:: php
+
+    $tempUrl = $object->getTemporaryUrl(60, 'GET');    
+    $url = $tempUrl.'&filename='.$label;
+
+
 Hosting HTML sites on CDN
 =========================
 


### PR DESCRIPTION
I propose to add instructions override TempURL file names, it took me some time to figure out how to do it. It is mentioned in the Rackspace cloud files developer guide (http://docs.rackspace.com/files/api/v1/cf-devguide/content/TempURL_File_Name_Overrides-d1e213.html) but I could find no mention in this documentation. I found  the solution in a blog post from 2013: http://blog.rackspace.com/cloud-files-update-new-api-only-and-control-panel-features/?cm_mmc=Social-_-FaceBook-_-Blog-_-CustRef&sf13063985=1

I tried it, it works.