### PR TITLE
Autoload tests only for dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,12 @@
     ],
     "autoload": {
         "psr-0": {
-            "OpenCloud": ["lib/", "tests/"]
+            "OpenCloud": ["lib/"]
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "OpenCloud": ["tests/"]
         }
     },
     "require": {


### PR DESCRIPTION
This will prevent people that require the library in composer getting the tests in their optimised composer classmap.