### PR TITLE
refactored load balancer node adding to use one request instead of se…

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php
+++ b/lib/OpenCloud/LoadBalancer/Resource/LoadBalancer.php
@@ -255,17 +255,20 @@ class LoadBalancer extends PersistentResource implements HasPtrRecordsInterface
             );
         }
 
-        $requests = array();
+        $requestData = array('nodes' => array());
 
+        /** @var Node $node */
         foreach ($this->nodes as $node) {
             // Only add the node if it is new
             if (null === $node->getId()) {
-                $json = json_encode($node->createJson());
-                $requests[] = $this->getClient()->post($node->getUrl(), self::getJsonHeader(), $json);
+                $nodeJson = $node->createJson();
+                $requestData['nodes'][] = $nodeJson['nodes'][0];
             }
         }
 
-        return $this->getClient()->send($requests);
+        $request = $this->getClient()->post($node->getUrl(), self::getJsonHeader(), json_encode($requestData));
+
+        return $this->getClient()->send($request);
     }
 
     /**


### PR DESCRIPTION
When using the SDK to add more than one node to an existing load balancer, it is very likely, that at least one request fails with a 422 (Unprocessable Entity) error, since the load balancer is in state PENDING_UPDATE  after the first request has been processed.

This PR changes the call to the API so that there are not several parallel requests, but just one, adding all nodes to add in just one call.
