### PR TITLE
Add delete object method in the container of ObjectStore.

### DIFF
--- a/doc/services/object-store/objects.rst
+++ b/doc/services/object-store/objects.rst
@@ -495,9 +495,20 @@ filenames inside the archive.
 
 `Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/auto-extract-archive-files.php>`_
 
-
 Delete object
--------------
+---------------------------------
+
+.. code-block:: php
+
+  /** @var bool $deleted */
+  $deleted = $container->deleteObject('{objectName}');
+
+
+`Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/delete-object-without-download.php>`_
+
+
+Delete already downloaded object
+---------------------------------
 
 .. code-block:: php
 

--- a/doc/services/object-store/objects.rst
+++ b/doc/services/object-store/objects.rst
@@ -500,8 +500,7 @@ Delete object
 
 .. code-block:: php
 
-  /** @var bool $deleted */
-  $deleted = $container->deleteObject('{objectName}');
+ $container->deleteObject('{objectName}');
 
 
 `Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/delete-object-without-download.php>`_

--- a/lib/OpenCloud/ObjectStore/Resource/Container.php
+++ b/lib/OpenCloud/ObjectStore/Resource/Container.php
@@ -236,6 +236,28 @@ class Container extends AbstractContainer
     }
 
     /**
+     * Delete an object from the API.
+     *
+     * @param string $name The name of object you want to delete
+     * @return True if object was delete with success. False if an error occurred
+     * @throws ObjectNotFoundException When the file you want to delete is not found
+     */
+    public function deleteObject($name)
+    {
+        try {
+            $response = $this->getClient()
+                    ->delete($this->getUrl($name))
+                    ->send();
+            return ($response->getStatusCode() == 204);
+        } catch (BadResponseException $e) {
+            if ($e->getResponse()->getStatusCode() == 404) {
+                throw ObjectNotFoundException::factory($name, $e);
+            }
+        }
+        return false;
+    }
+
+    /**
      * Creates a Collection of objects in the container
      *
      * @param array $params associative array of parameter values.

--- a/lib/OpenCloud/ObjectStore/Resource/Container.php
+++ b/lib/OpenCloud/ObjectStore/Resource/Container.php
@@ -243,7 +243,7 @@ class Container extends AbstractContainer
      */
     public function deleteObject($name)
     {
-        $response = $this->getClient()
+        $this->getClient()
             ->delete($this->getUrl($name))
             ->send();
     }

--- a/lib/OpenCloud/ObjectStore/Resource/Container.php
+++ b/lib/OpenCloud/ObjectStore/Resource/Container.php
@@ -239,22 +239,13 @@ class Container extends AbstractContainer
      * Delete an object from the API.
      *
      * @param string $name The name of object you want to delete
-     * @return True if object was delete with success. False if an error occurred
-     * @throws ObjectNotFoundException When the file you want to delete is not found
+     * @throws \Guzzle\Http\Exception\BadResponseException When an error occurred
      */
     public function deleteObject($name)
     {
-        try {
-            $response = $this->getClient()
-                    ->delete($this->getUrl($name))
-                    ->send();
-            return ($response->getStatusCode() == 204);
-        } catch (BadResponseException $e) {
-            if ($e->getResponse()->getStatusCode() == 404) {
-                throw ObjectNotFoundException::factory($name, $e);
-            }
-        }
-        return false;
+        $response = $this->getClient()
+            ->delete($this->getUrl($name))
+            ->send();
     }
 
     /**

--- a/samples/ObjectStore/delete-object-without-download.php
+++ b/samples/ObjectStore/delete-object-without-download.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright 2012-2014 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require dirname(__DIR__) . '/../vendor/autoload.php';
+
+use OpenCloud\Rackspace;
+
+// 1. Instantiate a Rackspace client. You can replace {authUrl} with
+// Rackspace::US_IDENTITY_ENDPOINT or similar
+$client = new Rackspace('{authUrl}', array(
+    'username' => '{username}',
+    'apiKey'   => '{apiKey}',
+));
+
+// 2. Obtain an Object Store service object from the client.
+$objectStoreService = $client->objectStoreService(null, '{region}');
+
+// 3. Get container.
+$container = $objectStoreService->getContainer('{containerName}');
+
+// 4. Delete object.
+$container->deleteObject('{objectName}');

--- a/tests/OpenCloud/Tests/ObjectStore/Resource/ContainerTest.php
+++ b/tests/OpenCloud/Tests/ObjectStore/Resource/ContainerTest.php
@@ -118,6 +118,32 @@ class ContainerTest extends ObjectStoreTestCase
         $container->delete();
     }
 
+    public function test_Delete_Object()
+    {
+        $container = $this->container;
+        $this->addMockSubscriber($this->makeResponse('[]', 204));
+        $response = $container->deleteObject("someObject");
+        $this->assertTrue($response);
+    }
+
+    public function test_Delete_Object_With_Failure()
+    {
+        $container = $this->container;
+        $this->addMockSubscriber($this->makeResponse('[]', 500));
+        $response = $container->deleteObject("someObject");
+        $this->assertFalse($response);
+    }
+
+    /**
+     * @expectedException \OpenCloud\ObjectStore\Exception\ObjectNotFoundException
+     */
+    public function test_Delete_NonExisting_Object()
+    {
+        $container = $this->container;
+        $this->addMockSubscriber($this->makeResponse('[]', 404));
+        $container->deleteObject("someObject");
+    }
+
     public function test_Object_List()
     {
         $container = $this->container;

--- a/tests/OpenCloud/Tests/ObjectStore/Resource/ContainerTest.php
+++ b/tests/OpenCloud/Tests/ObjectStore/Resource/ContainerTest.php
@@ -122,20 +122,21 @@ class ContainerTest extends ObjectStoreTestCase
     {
         $container = $this->container;
         $this->addMockSubscriber($this->makeResponse('[]', 204));
-        $response = $container->deleteObject("someObject");
-        $this->assertTrue($response);
+        $container->deleteObject("someObject");
     }
 
+    /**
+     * @expectedException \Guzzle\Http\Exception\BadResponseException
+     */
     public function test_Delete_Object_With_Failure()
     {
         $container = $this->container;
         $this->addMockSubscriber($this->makeResponse('[]', 500));
-        $response = $container->deleteObject("someObject");
-        $this->assertFalse($response);
+        $container->deleteObject("someObject");
     }
 
     /**
-     * @expectedException \OpenCloud\ObjectStore\Exception\ObjectNotFoundException
+     * @expectedException \Guzzle\Http\Exception\BadResponseException
      */
     public function test_Delete_NonExisting_Object()
     {


### PR DESCRIPTION
Hi everybody,

I add deleteObject method in the container class of object storage API.
This method is faster than the previous way to delete an object from the object storage.

According to the documentation, previously you must download the object and after delete it.
The first step isn't always relevant (Can generate some performance issue if the object is big).

``` php
$container = $objectStoreService->getContainer('{containerName}');
$object = $container->getObject('{objectName}'); // Can be long for big file
$object->delete();
```

Now you can delete it without downloaded it.

``` php
$container = $objectStoreService->getContainer('{containerName}');
$container->deleteObject('{objectName}');
```

Have fun ;)
