### PR TITLE
Fix temp public URL missing file path info

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/DataObject.php
+++ b/lib/OpenCloud/ObjectStore/Resource/DataObject.php
@@ -481,7 +481,11 @@ class DataObject extends AbstractResource
         }
         // @codeCoverageIgnoreEnd
 
-        $url = ($forcePublicUrl === true) ? $this->getService()->getEndpoint()->getPublicUrl() : $this->getUrl();
+        $url = $this->getUrl();
+        if ($forcePublicUrl === true) {
+            $url->setHost($this->getService()->getEndpoint()->getPublicUrl()->getHost());
+        }
+
         $urlPath = urldecode($url->getPath());
         $body = sprintf("%s\n%d\n%s", $method, $expiry, $urlPath);
         $hash = hash_hmac('sha1', $body, $secret);

--- a/tests/OpenCloud/Tests/ObjectStore/Resource/DataObjectTest.php
+++ b/tests/OpenCloud/Tests/ObjectStore/Resource/DataObjectTest.php
@@ -111,6 +111,9 @@ class DataObjectTest extends ObjectStoreTestCase
 
         // Check that internal URLs are NOT used
         $this->assertNotContains('snet-storage', $tempUrl);
+
+        // Check that the URL contains the required file path
+        $this->assertContains('/foo/bar', $tempUrl);
     }
 
     public function test_Purge()


### PR DESCRIPTION
Should fix #648
Using `combine` didn't work, as it would either override the path info, or would override the external host info with the internal host, depending on order of combine.