### PR TITLE
Updated bulk delete method call in docs

### DIFF
--- a/doc/services/object-store/objects.rst
+++ b/doc/services/object-store/objects.rst
@@ -525,7 +525,7 @@ Bulk delete a set of paths:
 
   $pathsToBeDeleted = array('/container_1/old_file', '/container_2/notes.txt', '/container_1/older_file.log');
 
-  $service->bulkDelete($pathsToBeDeleted);
+  $service->batchDelete($pathsToBeDeleted);
 
 `Get the executable PHP script for this example <https://raw.githubusercontent.com/rackspace/php-opencloud/master/samples/ObjectStore/bulk-delete.php>`_
 

--- a/samples/ObjectStore/bulk-delete.php
+++ b/samples/ObjectStore/bulk-delete.php
@@ -31,7 +31,7 @@ $client = new Rackspace('{authUrl}', array(
 $objectStoreService = $client->objectStoreService(null, '{region}');
 
 // 3. Bulk delete objects and empty containers.
-$response = $objectStoreService->bulkDelete(array(
+$response = $objectStoreService->batchDelete(array(
     '{container1}/{objectName}',
     '{container2}/{objectName}',
     '{container3}'


### PR DESCRIPTION
Just realized that bulkDelete was deprecated so I made a small change to the docs to show the updated method call.
