### PR TITLE
create subnet without gateway

### DIFF
--- a/lib/OpenCloud/Common/Resource/PersistentResource.php
+++ b/lib/OpenCloud/Common/Resource/PersistentResource.php
@@ -219,6 +219,8 @@ abstract class PersistentResource extends BaseResource
         foreach ($this->createKeys as $key) {
             if (null !== ($property = $this->getProperty($key))) {
                 $element->{$this->getAlias($key)} = $this->recursivelyAliasPropertyValue($property);
+            } elseif ($key == 'gatewayIp') {
+                $element->{$this->getAlias($key)} = null;
             }
         }
 


### PR DESCRIPTION
According to the api ref of openstack,When we want to specify a subnet without a gateway, set the gateway_ip attribute to null in the request body. But the function createJson in PersistentResource  will remove the null attribute. This will solve the problem
