### PR TITLE
Fix segment name to avoid corrupted retrieval of a file with 10 or more segments

### DIFF
--- a/lib/OpenCloud/ObjectStore/Upload/TransferPart.php
+++ b/lib/OpenCloud/ObjectStore/Upload/TransferPart.php
@@ -135,7 +135,7 @@ class TransferPart
      */
     public static function createRequest($part, $number, $client, $options)
     {
-        $name = sprintf('%s/%s/%d', $options['objectName'], $options['prefix'], $number);
+        $name = sprintf('%s/%s/%05d', $options['objectName'], $options['prefix'], $number);
         $url = clone $options['containerUrl'];
         $url->addPath($name);
 


### PR DESCRIPTION
Zero-padding the segment number to 5 digits allows to support the minimum chunk size of 1MB and the maximum of 5GB.

Without padding, when retrieving a file segmented in 10 or more segments, it will be reassembled in the wrong order and thus will be rendered useless.

Fixes issue [#679](https://github.com/rackspace/php-opencloud/issues/679).
