### PR TITLE
Composer Update Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     },
     "require": {
         "php" : ">=5.4",
-        "guzzle/guzzle" : "~3.8",
         "psr/log": "~1.0",
-        "mikemccabe/json-patch-php": "~0.1"
+        "mikemccabe/json-patch-php": "~0.1",
+        "guzzlehttp/guzzle": "~5.0"
     },
     "require-dev" : {
         "phpunit/phpunit": "4.3.*",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev" : {
         "phpunit/phpunit": "4.3.*",
         "phpspec/prophecy": "~1.4",
-        "satooshi/php-coveralls": "0.6.*@dev",
+        "satooshi/php-coveralls": "~1.0",
         "jakub-onderka/php-parallel-lint": "0.*",
         "fabpot/php-cs-fixer": "1.0.*@dev",
         "apigen/apigen": "~4.0"


### PR DESCRIPTION
The `guzzle/guzzle` composer package has been deprecated in favour of `httpguzzle/guzzle`.

I updated the composer file to require version 5 of guzzle, which is still compatible with PHP 5.4.

I also upgraded `satooshi/php-coveralls` to a new version to resolve a conflict that occurred during composer install:

```
php-opencloud$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - satooshi/php-coveralls v0.6.0 requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - satooshi/php-coveralls v0.6.1 requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - Conclusion: don't install psr/log 1.0.0
    - Installation request for satooshi/php-coveralls 0.6.*@dev -> satisfiable by satooshi/php-coveralls[v0.6.0, v0.6.1].
```

After this, `fabpot/php-cs-fixer` and `guzzle/guzzle` are still flagged as abandoned while installing dev, but not while installing with the `--no-dev` flag.