### PR TITLE
remove sdk-support email

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,9 +67,6 @@ have a `mailing list <https://groups.google.com/forum/#!forum/php-opencloud>`_,
 so feel free to join to keep up to date with all the latest changes and
 announcements to the library.
 
-For general feedback and support requests, send an email to
-sdk-support@rackspace.com.
-
 You can also find assistance via IRC on #rackspace at freenode.net.
 
 Contributing


### PR DESCRIPTION
since it's no longer monitored
partially closes #702 