### PR TITLE
Fix certificateMappingList returning valid CertificateMappings when iterated

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
+++ b/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
@@ -102,7 +102,8 @@ class CertificateMapping extends PersistentResource
      *
      * @var array|object $values
      */
-    protected function setCertificateMapping($values) {
+    protected function setCertificateMapping($values)
+    {
         $this->populate($values);
     }
 }

--- a/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
+++ b/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
@@ -93,4 +93,16 @@ class CertificateMapping extends PersistentResource
 
         return $object;
     }
+
+    /**
+     * Sets properties from array || object of $values
+     *
+     * Used by LoadBalancer::certificateMappingList's paginated iterator
+     * to return CertificateMappings with a valid id and hostname
+     *
+     * @var array|object $values
+     */
+    protected function setCertificateMapping($values) {
+        $this->populate($values);
+    }
 }


### PR DESCRIPTION
The following code was returning empty CertificateMapping objects when iterated.

```
// snippet roughly from the documentation...
$mappingsIterator = $loadBalancer->certificateMappingList();
while ($mappingsIterator->valid()) {
    $mapping = $mappingsIterator->current();
    echo $mapping->id; // EMPTY ID
    $mappingsIterator->next();
}

// the foreach syntax has the same problem...
```
Inspecting the $elements property on $mappingsIterator was showing the elements in the following structure with correct values:

```
$elements = [
    0=>{
        certificateMapping => {
            id: 1234
            hostName: whatever.com
        }
    },
    1=>{...}
    2=>{...}
]
````

However, looping the iterator was returning CertificateMapping objects without the id and hostName properties set.  This was caused because of the second level in the $elements array being passed into ```populate```, recognizing that there is no property called "certificateMapping" and issuing a warning "Attempted to set certificateMapping with value {id...hostname...}, but the property has not been defined. Please define first."

Adding this method allows ```populate``` to recognize that certificateMapping structure and repopulate with the actual values.

It now returns valid CertificateMapping objects with the id and hostname set, making it actually useful.

There were no tests to this portion of the platform so I did not add any to check this behavior.
