### PR TITLE
Simplify example for listing more than 10,000 files

### DIFF
--- a/samples/ObjectStore/list-objects-over-10000.php
+++ b/samples/ObjectStore/list-objects-over-10000.php
@@ -37,26 +37,20 @@ $objects = $container->objectList();
 
 // 5. Create a list of all objects in the container
 $containerObjects = array();
-$marker = '';
+$latestFilename = '';
+$batchCount = null;
 
-while ($marker !== null) {
+while ($batchCount !== 0) {
     $params = array(
-        'marker' => $marker,
+        'marker' => $latestFilename,
     );
 
     $objects = $container->objectList($params);
-    $total = $objects->count();
-    $count = 0;
-
-    if ($total == 0) {
-        break;
-    }
+    $batchCount = $objects->count();
 
     foreach ($objects as $object) {
-        /** @var $object OpenCloud\ObjectStore\Resource\DataObject **/
-        $containerObjects[] = $object->getName();
-        $count++;
-
-        $marker = ($count == $total) ? $object->getName() : null;
+        /** @var $object \OpenCloud\ObjectStore\Resource\DataObject **/
+        $latestFilename = $object->getName();
+        $containerObjects[] = $latestFilename;
     }
 }


### PR DESCRIPTION
The old example doesn't actually work as $total is the size of the current batch, not the total number of objects in the container. Since $marker gets set to null when $count equals $total, the example never outputs anything more than one batch of 10,000.

New method simply outputs batch after batch until there are no more files (i.e. it doesn't break until after the last filename). No need to keep track of the overall count or anything like that.

I tried to update the docs too but had some trouble with Sphinx.