### PR TITLE
Fix invalid PHPDoc

### DIFF
--- a/lib/OpenCloud/ObjectStore/Resource/AbstractResource.php
+++ b/lib/OpenCloud/ObjectStore/Resource/AbstractResource.php
@@ -19,7 +19,9 @@ namespace OpenCloud\ObjectStore\Resource;
 
 use Guzzle\Http\Message\Response;
 use OpenCloud\Common\Base;
+use OpenCloud\Common\Http\Client;
 use OpenCloud\Common\Service\ServiceInterface;
+use OpenCloud\ObjectStore\Service;
 
 /**
  * Abstract base class which implements shared functionality of ObjectStore
@@ -36,7 +38,7 @@ abstract class AbstractResource extends Base
     /** @var string The FQCN of the metadata object used for the container. */
     protected $metadataClass = 'OpenCloud\\Common\\Metadata';
 
-    /** @var \OpenCloud\Common\Service\ServiceInterface The service object. */
+    /** @var Service The service object. */
     protected $service;
 
     public function __construct(ServiceInterface $service)
@@ -230,7 +232,7 @@ abstract class AbstractResource extends Base
     /**
      * To delete or unset a particular metadata item.
      *
-     * @param $key Metadata key to unset
+     * @param string $key Metadata key to unset
      * @return Response HTTP response returned from API operation to unset metadata item.
      */
     public function unsetMetadataItem($key)


### PR DESCRIPTION
The classes were not referenced and thus the PHPDoc not valid as pointed out by PHPStorm and Phan when running on @nextcloud:

```
apps/files_external/lib/Lib/Storage/Swift.php:387 PhanUndeclaredClassMethod Call to method get from undeclared class \OpenCloud\ObjectStore\Resource\Client
```

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>