### PR TITLE
Return null on empty json string in PHP7

### DIFF
--- a/lib/OpenCloud/Common/Http/Message/Formatter.php
+++ b/lib/OpenCloud/Common/Http/Message/Formatter.php
@@ -28,6 +28,9 @@ class Formatter
     {
         if (strpos($response->getHeader(Header::CONTENT_TYPE), Mime::JSON) !== false) {
             $string = (string) $response->getBody();
+            if ('' === $string) {
+                return null;
+            }
             $response = json_decode($string);
             self::checkJsonError($string);
 


### PR DESCRIPTION
PHP7 no longer considers an empty string as valid JSON. 

When passing an empty string to ```json_decode``` an exception is raised instead of returning ```null```.

This is documented on the PHP7 [Backward incompatible changes](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.json-to-jsond) page.

I have updated the method to check for an empty response string and return ```null``` instead.