### PR TITLE
certificateMappingList returned data not populating Resource

### DIFF
--- a/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
+++ b/lib/OpenCloud/LoadBalancer/Resource/CertificateMapping.php
@@ -106,4 +106,23 @@ class CertificateMapping extends PersistentResource
     {
         $this->populate($values);
     }
+
+    /**
+     * Sets returned certificateMapping property to individual CertificateMapping fields
+     * @var array|object $data
+     */
+    protected function setCertificateMapping($data)
+    {
+       foreach($this->createKeys as $key) {
+           if(is_object($data)) {
+               if(isset($data->{$key})) {
+                   $this->setProperty($key, $data->{$key});
+               }
+           } else {
+               if (isset($data[$key])) {
+                   $this->setProperty($key, $data[$key]);
+               }
+           }
+       }
+    }
 }


### PR DESCRIPTION
There is an issue with the certificateMappingList() object as it does not correct populate a CertificateMapping Resource due to the API returning CertificateMapping information wrapped in a "certificateMapping" object.

Response:
`{
  "certificateMappings": [
    {
      "certificateMapping": {
        "id": 123,
        "hostName": "rackspace.com"
      }
    },
    {
      "certificateMapping": {
        "id": 124,
        "hostName": "*.rackspace.com"
      }
    }
  ]
}` 

PHP Resource expected the following to correctly populate the object:
`{
  "certificateMappings": [
    {
      "id": 123,
      "hostName": "rackspace.com"
    },
    {
      "id": 124,
      "hostName": "*.rackspace.com"
    }
  ]
}` 

