### PR TITLE
protect - (not a range)

### DIFF
--- a/lib/OpenCloud/Compute/Resource/KeyPair.php
+++ b/lib/OpenCloud/Compute/Resource/KeyPair.php
@@ -41,7 +41,7 @@ class KeyPair extends PersistentObject
 
     public function setName($name)
     {
-        if (preg_match('#[^\w\d\s-_]#', $name) || strlen($name) > 255) {
+        if (preg_match('#[^\w\d\s\-_]#', $name) || strlen($name) > 255) {
             throw new InvalidArgumentError(sprintf(
                 'The key name may not exceed 255 characters. It can contain the'
                 . ' following characters: alphanumeric, spaces, dashes and'


### PR DESCRIPTION
fix PHP 7.3 warning "preg_match(): Compilation failed: invalid range in character class at offset 8"


From Fedora QA
https://apps.fedoraproject.org/koschei/package/php-opencloud?collection=f30